### PR TITLE
add black to tests checks

### DIFF
--- a/flask_resources/args/paginate.py
+++ b/flask_resources/args/paginate.py
@@ -50,11 +50,7 @@ def build_pagination(request_args):
                 from_idx=request_args["from"] - 1,
                 to_idx=request_args["from"] - 1 + request_args["size"],
                 links=dict(
-                    prev={
-                        "from": max(
-                            1, request_args["from"] - request_args["size"]
-                        )
-                    },
+                    prev={"from": max(1, request_args["from"] - request_args["size"])},
                     self={"from": request_args["from"]},
                     next={"from": request_args["from"] + request_args["size"]},
                 ),

--- a/flask_resources/content_negotiation.py
+++ b/flask_resources/content_negotiation.py
@@ -18,8 +18,7 @@ class ContentNegotiator(object):
     """
 
     @classmethod
-    def match(cls, mimetypes, accept_mimetypes, formats_map, format,
-              default=None):
+    def match(cls, mimetypes, accept_mimetypes, formats_map, format, default=None):
         """Select the MIME type which best matches the client request.
 
         :param mimetypes: List/set of available MIME types.
@@ -29,8 +28,9 @@ class ContentNegotiator(object):
         :param format: The client's selected format.
         :param default: Default MIMEtype if a wildcard was received.
         """
-        return cls.match_by_format(formats_map, format) or \
-            cls.match_by_accept(mimetypes, accept_mimetypes, default=default)
+        return cls.match_by_format(formats_map, format) or cls.match_by_accept(
+            mimetypes, accept_mimetypes, default=default
+        )
 
     @classmethod
     def match_by_accept(cls, mimetypes, accept_mimetypes, default=None):
@@ -46,10 +46,10 @@ class ContentNegotiator(object):
         for client_accept, quality in accept_mimetypes:
             if quality <= best_quality:
                 continue
-            if client_accept == '*/*':
+            if client_accept == "*/*":
                 has_wildcard = True
             for m in mimetypes:
-                if m in ['*/*', client_accept] and quality > 0:
+                if m in ["*/*", client_accept] and quality > 0:
                     best_quality = quality
                     best = m
 

--- a/flask_resources/context.py
+++ b/flask_resources/context.py
@@ -41,11 +41,7 @@ class ResourceRequestCtx(object):
     """
 
     def __init__(
-        self,
-        accept_mimetype=None,
-        payload_mimetype=None,
-        request_args=None,
-        data=None,
+        self, accept_mimetype=None, payload_mimetype=None, request_args=None, data=None,
     ):
         """Initialize the resource context."""
         self.accept_mimetype = accept_mimetype
@@ -65,6 +61,7 @@ class ResourceRequestCtx(object):
 
 def with_resource_requestctx(f):
     """Wrap in resource request context."""
+
     @wraps(f)
     def inner(*args, **kwargs):
         with ResourceRequestCtx():

--- a/flask_resources/errors.py
+++ b/flask_resources/errors.py
@@ -96,9 +96,7 @@ class SearchPaginationRESTError(RESTException):
         if errors:
             for field, messages in errors.items():
                 _errors.extend([FieldError(field, msg) for msg in messages])
-        super(SearchPaginationRESTError, self).__init__(
-            errors=_errors, **kwargs
-        )
+        super(SearchPaginationRESTError, self).__init__(errors=_errors, **kwargs)
 
 
 # class InvalidContentType(RESTException):

--- a/flask_resources/ext.py
+++ b/flask_resources/ext.py
@@ -18,4 +18,4 @@ class FlaskResources(object):
 
     def init_app(self, app):
         """Flask application initialization."""
-        app.extensions['flask-resources'] = self
+        app.extensions["flask-resources"] = self

--- a/flask_resources/resources.py
+++ b/flask_resources/resources.py
@@ -70,8 +70,7 @@ class Resource(object):
             {
                 "rule": self.config.item_route,
                 "view_func": ItemView.as_view(
-                    name="{}{}".format(bp_name, ITEM_VIEW_SUFFIX),
-                    resource=self,
+                    name="{}{}".format(bp_name, ITEM_VIEW_SUFFIX), resource=self,
                 ),
             }
         ]
@@ -114,15 +113,13 @@ class CollectionResource(Resource):
             {
                 "rule": self.config.item_route,
                 "view_func": ItemView.as_view(
-                    name="{}{}".format(bp_name, ITEM_VIEW_SUFFIX),
-                    resource=self,
+                    name="{}{}".format(bp_name, ITEM_VIEW_SUFFIX), resource=self,
                 ),
             },
             {
                 "rule": self.config.list_route,
                 "view_func": ListView.as_view(
-                    name="{}{}".format(bp_name, LIST_VIEW_SUFFIX),
-                    resource=self,
+                    name="{}{}".format(bp_name, LIST_VIEW_SUFFIX), resource=self,
                 ),
             },
         ]
@@ -137,8 +134,7 @@ class SingletonResource(Resource):
             {
                 "rule": self.config.list_route,
                 "view_func": SingletonView.as_view(
-                    name="{}{}".format(bp_name, SINGLETON_VIEW_SUFFIX),
-                    resource=self,
+                    name="{}{}".format(bp_name, SINGLETON_VIEW_SUFFIX), resource=self,
                 ),
             }
         ]

--- a/flask_resources/version.py
+++ b/flask_resources/version.py
@@ -11,4 +11,4 @@ This file is imported by ``flask_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.0.1'
+__version__ = "0.1.0"

--- a/flask_resources/views/singleton.py
+++ b/flask_resources/views/singleton.py
@@ -17,9 +17,7 @@ class SingletonView(BaseView):
     Note that the resource route should contain the `<id>` param.
     """
 
-    def __init__(
-        self, resource=None, item_parser=item_request_parser, *args, **kwargs
-    ):
+    def __init__(self, resource=None, item_parser=item_request_parser, *args, **kwargs):
         """Constructor."""
         super(SingletonView, self).__init__(resource=resource, *args, **kwargs)
         self.item_parser = item_parser

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,5 +7,6 @@
 
 [pytest]
 pep8ignore = docs/conf.py ALL
+pep8maxlinelength = 88
 addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=flask_resources --cov-report=term-missing
 testpaths = docs tests flask_resources

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,7 +7,8 @@
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 pydocstyle flask_resources tests docs && \
-isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses -rc -c -df && \
+isort --multi-line=3 --line-width=88 --trailing-comma --force-grid-wrap=0 --use-parentheses -rc -c -df && \
+black --check --diff flask_resources && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 pytest

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ tests_require = [
     "pydocstyle>=2.0.0",
     "pytest-cov>=2.5.1",
     "pytest-pep8>=1.0.6",
+    "black>=19.10b0",
 ]
 
 extras_require = {


### PR DESCRIPTION
Requires #1 and needs to be rebased once that is merged. This should only contain `run-tests.sh` changes (so if reviewing, review only that file).

Closes https://github.com/inveniosoftware/flask-resources/issues/13

Note that the `isort` command has change the `line-length` by `line-width`. I would like someone to crosscheck this since I do not see anything in the changelog nor the code. However in my PC the output is:

``` console
 $isort --help | grep line
                        Adds the specified import line to all files,
                        prints them to the command line without modifying the
  -ca, --combine-as     Combines as imports on the same line.
  -e, --balanced        Balances wrapping to produce the most consistent line
                        grid wrapped regardless of line length
  -l LINE_LENGTH, --lines LINE_LENGTH
                        [Deprecated] The max length of an import line (used
  -lai LINES_AFTER_IMPORTS, --lines-after-imports LINES_AFTER_IMPORTS
  -lbt LINES_BETWEEN_TYPES, --lines-between-types LINES_BETWEEN_TYPES
  -le LINE_ENDING, --line-ending LINE_ENDING
                        Forces line endings to the specified value. If not
  -m {0,1,2,3,4,5,6,7}, --multi-line {0,1,2,3,4,5,6,7}
                        Multi line output (0-grid, 1-vertical, 2-hanging,
  -nis, --no-inline-sort
  -nlb NO_LINES_BEFORE, --no-lines-before NO_LINES_BEFORE
                        empty lines
  -sl, --force-single-line-imports
                        Forces all from imports to appear on their own line
                        Includes a trailing comma on multi line imports that
                        Use parenthesis for line continuation on length limit
  -w LINE_LENGTH, --line-width LINE_LENGTH
                        The max length of an import line (used for wrapping
                        Specifies how long lines that are wrapped should be,
                        if not set line_length is used.
```

For isort version 4.3.21