### PR TITLE
Serializer

### DIFF
--- a/flask_resources/args/__init__.py
+++ b/flask_resources/args/__init__.py
@@ -7,6 +7,16 @@
 
 """Library for easily implementing REST APIs."""
 
-from .parsers import RequestParser
+from .parsers import (
+    RequestParser,
+    create_request_parser,
+    item_request_parser,
+    search_request_parser,
+)
 
-__all__ = "RequestParser"
+__all__ = (
+    "RequestParser",
+    "create_request_parser",
+    "item_request_parser",
+    "search_request_parser",
+)

--- a/flask_resources/context.py
+++ b/flask_resources/context.py
@@ -5,7 +5,7 @@
 # Flask-Resources is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-"""Module tests."""
+"""Resource Request context."""
 
 from functools import wraps
 

--- a/flask_resources/errors.py
+++ b/flask_resources/errors.py
@@ -13,8 +13,6 @@ from flask import g
 from werkzeug.exceptions import HTTPException
 from werkzeug.http import http_date
 
-# FIXME: (LARS) This has to be reviewed
-
 
 class RESTException(HTTPException):
     """HTTP Exception delivering JSON error responses."""
@@ -97,6 +95,21 @@ class SearchPaginationRESTError(RESTException):
             for field, messages in errors.items():
                 _errors.extend([FieldError(field, msg) for msg in messages])
         super(SearchPaginationRESTError, self).__init__(errors=_errors, **kwargs)
+
+
+#
+# Loading/Serializing
+#
+class UnsupportedMediaRESTError(RESTException):
+    """Creating record with unsupported media type."""
+
+    code = 415
+
+    def __init__(self, content_type=None, **kwargs):
+        """Initialize exception."""
+        super(UnsupportedMediaRESTError, self).__init__(**kwargs)
+        content_type = content_type
+        self.description = 'Unsupported media type "{0}".'.format(content_type)
 
 
 # class InvalidContentType(RESTException):

--- a/flask_resources/loaders.py
+++ b/flask_resources/loaders.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Flask-Resources is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Request loader view."""
+
+
+def load_request(self):
+    """Load item from request."""
+    pass

--- a/flask_resources/loaders/__init__.py
+++ b/flask_resources/loaders/__init__.py
@@ -7,7 +7,7 @@
 
 """Loaders."""
 
-from .json import JSONLoader
+from .json import JSONLoader, JSONPatchLoader
 from .loaders import LoaderMixin
 
 __all__ = ("JSONLoader", "JSONPatchLoader", "LoaderMixin")

--- a/flask_resources/loaders/__init__.py
+++ b/flask_resources/loaders/__init__.py
@@ -5,9 +5,9 @@
 # Flask-Resources is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-"""Request loader view."""
+"""Loaders."""
 
+from .json import JSONLoader
+from .loaders import LoaderMixin
 
-def load_request(self):
-    """Load item from request."""
-    pass
+__all__ = ("JSONLoader", "JSONPatchLoader", "LoaderMixin")

--- a/flask_resources/loaders/json.py
+++ b/flask_resources/loaders/json.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Flask-Resources is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""JSON loader."""
+
+from flask import request
+
+from .loaders import LoaderMixin
+
+
+class JSONLoader(LoaderMixin):
+    """JSON loader."""
+
+    def load_request(self, *args, **kwargs):
+        """Load the body of the request."""
+        return request.get_json()
+
+
+class JSONPatchLoader(LoaderMixin):
+    """JSON+Patch loader."""
+
+    def load_request(self, *args, **kwargs):
+        """Load the body of the request."""
+        return request.get_json(force=True)

--- a/flask_resources/loaders/loaders.py
+++ b/flask_resources/loaders/loaders.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Flask-Resources is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Loaders required interfaces."""
+
+
+class LoaderMixin:
+    """Loader Interface."""
+
+    def load_request(self, *args, **kwargs):
+        """Load the body of the request."""
+        raise NotImplementedError()

--- a/flask_resources/resources.py
+++ b/flask_resources/resources.py
@@ -9,6 +9,7 @@
 
 from flask import Blueprint
 
+from .loaders import JSONLoader, JSONPatchLoader
 from .response import ItemResponse, ListResponse
 from .serializers import JSONSerializer
 from .views import ItemView, ListView, SingletonView
@@ -21,8 +22,14 @@ SINGLETON_VIEW_SUFFIX = "_singleton_view"
 class ResourceConfig:
     """Base resource configuration."""
 
-    item_handlers = {"application/json": ItemResponse(JSONSerializer)}
-    list_handlers = {"application/json": ListResponse(JSONSerializer)}
+    item_request_loaders = {
+        "application/json": JSONLoader(),
+        "application/json+patch": JSONPatchLoader(),
+    }
+    item_response_handlers = {"application/json": ItemResponse(JSONSerializer)}
+    item_route = "resources/<id>"
+    list_response_handlers = {"application/json": ListResponse(JSONSerializer)}
+    list_route = "resources/"
 
 
 class Resource:
@@ -36,9 +43,6 @@ class Resource:
     # Primary interface
     def search(self, request_context):
         """Perform a search over the items."""
-        # TODO: the resource itself shouldn't be "request"-aware. Returning of
-        # HTTP responses should be done in views. Maybe some base
-        # error/exception classes can be defined to help?
         return 405
 
     def create(self):

--- a/flask_resources/resources.py
+++ b/flask_resources/resources.py
@@ -9,6 +9,8 @@
 
 from flask import Blueprint
 
+from .response import ItemResponse, ListResponse
+from .serializers import JSONSerializer
 from .views import ItemView, ListView, SingletonView
 
 ITEM_VIEW_SUFFIX = "_item_view"
@@ -16,10 +18,17 @@ LIST_VIEW_SUFFIX = "_list_view"
 SINGLETON_VIEW_SUFFIX = "_singleton_view"
 
 
-class Resource(object):
+class ResourceConfig:
+    """Base resource configuration."""
+
+    item_handlers = {"application/json": ItemResponse(JSONSerializer)}
+    list_handlers = {"application/json": ListResponse(JSONSerializer)}
+
+
+class Resource:
     """Resource controller interface."""
 
-    def __init__(self, config, *args, **kwargs):
+    def __init__(self, config=ResourceConfig, *args, **kwargs):
         """Initialize the base resource."""
         self.config = config
         self.bp_name = None

--- a/flask_resources/resources.py
+++ b/flask_resources/resources.py
@@ -9,6 +9,7 @@
 
 from flask import Blueprint
 
+from .args import create_request_parser, item_request_parser, search_request_parser
 from .loaders import JSONLoader, JSONPatchLoader
 from .response import ItemResponse, ListResponse
 from .serializers import JSONSerializer
@@ -26,10 +27,13 @@ class ResourceConfig:
         "application/json": JSONLoader(),
         "application/json+patch": JSONPatchLoader(),
     }
-    item_response_handlers = {"application/json": ItemResponse(JSONSerializer)}
-    item_route = "resources/<id>"
-    list_response_handlers = {"application/json": ListResponse(JSONSerializer)}
-    list_route = "resources/"
+    item_response_handlers = {"application/json": ItemResponse(JSONSerializer())}
+    item_route = "/resources/<id>"
+    list_response_handlers = {"application/json": ListResponse(JSONSerializer())}
+    list_route = "/resources/"
+    create_request_parser = create_request_parser
+    item_request_parser = item_request_parser
+    search_request_parser = search_request_parser
 
 
 class Resource:

--- a/flask_resources/resources.py
+++ b/flask_resources/resources.py
@@ -19,9 +19,8 @@ SINGLETON_VIEW_SUFFIX = "_singleton_view"
 class Resource(object):
     """Resource controller interface."""
 
-    def __init__(self, controller, config):
+    def __init__(self, config, *args, **kwargs):
         """Initialize the base resource."""
-        self.controller = controller
         self.config = config
         self.bp_name = None
 

--- a/flask_resources/resources.py
+++ b/flask_resources/resources.py
@@ -5,7 +5,7 @@
 # Flask-Resources is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-"""Library for easily implementing REST APIs."""
+"""Resource view."""
 
 from flask import Blueprint, abort
 

--- a/flask_resources/resources.py
+++ b/flask_resources/resources.py
@@ -7,7 +7,7 @@
 
 """Resource view."""
 
-from flask import Blueprint, abort
+from flask import Blueprint
 
 from .views import ItemView, ListView, SingletonView
 
@@ -31,27 +31,27 @@ class Resource(object):
         # TODO: the resource itself shouldn't be "request"-aware. Returning of
         # HTTP responses should be done in views. Maybe some base
         # error/exception classes can be defined to help?
-        abort(405)
+        return 405
 
     def create(self):
         """Create an item."""
-        abort(405)
+        return 405
 
     def read(self, *args, **kwargs):
         """Read an item."""
-        abort(405)
+        return 405
 
     def update(self, data, *args, **kwargs):
         """Update an item."""
-        abort(405)
+        return 405
 
     def partial_update(self, data, *args, **kwargs):
         """Partial update an item."""
-        abort(405)
+        return 405
 
     def delete(self, *args, **kwargs):
         """Delete an item."""
-        abort(405)
+        return 405
 
     # Secondary interface
     def as_blueprint(self, name, **bp_kwargs):
@@ -78,30 +78,6 @@ class Resource(object):
     def create_error_handlers(self):
         """Create error handlers."""
         return []
-
-    def load_item_from_request(self):
-        """Load item from request."""
-        # FIXME: Code default
-        # self.config.item_loader()
-        pass
-
-    def make_list_response(self, item_list, http_code):
-        """Make list response."""
-        # FIXME: Code default
-        # self.config.list_serializer()
-        pass
-
-    def make_item_response(self, item, http_code):
-        """Make item response."""
-        # FIXME: Code default
-        # self.config.item_serializer()
-        pass
-
-    def make_error_response(self, error_data, http_code):
-        """Make error response."""
-        # FIXME: Code default
-        # self.config.error_serializer()
-        pass
 
 
 class CollectionResource(Resource):

--- a/flask_resources/response.py
+++ b/flask_resources/response.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Flask-Resources is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Response module."""
+
+from flask import make_response
+
+
+class ResponseMixin:
+    """Response interface."""
+
+    def make_response(code, content):
+        """Builds a response."""
+        raise NotImplementedError()
+
+    def make_error_response(reason, message):
+        """Builds an error response."""
+        raise NotImplementedError()
+
+
+class ItemResponse(ResponseMixin):
+    """Item response representation.
+
+    Builds up a reponse for a single object.
+    """
+
+    def __init__(self, serializer=None, *args, **kwargs):
+        """Constructor."""
+        self.serializer = serializer
+
+    def make_response(code, content):
+        """Builds a response for a single object."""
+        # This should do the link building (e.g. sign posting): self, pagination, query, etc.
+        # In case of list responses, it would also take care of extras such as aggregation
+        make_response(
+            body=self.serializer.serialize_object(content),  # content is the object
+            status=code,
+            headers=self.make_header(),
+        )
+
+
+class ListResponse(ResponseMixin):
+    """List response representation.
+
+    Builds up a reponse for a list of objects.
+    """
+
+    def __init__(self, serializer=None, *args, **kwargs):
+        """Constructor."""
+        self.serializer = serializer
+
+    def make_response(code, content):
+        """Builds a response for a list of objects."""
+        # This should do the link building (e.g. sign posting): self, pagination, query, etc.
+        # In case of list responses, it would also take care of extras such as aggregation
+        make_response(
+            body=self.serializer.serialize_object(content),  # content is the object
+            response_code=code,
+            headers=self.make_header(),
+        )

--- a/flask_resources/response.py
+++ b/flask_resources/response.py
@@ -13,11 +13,15 @@ from flask import abort, make_response
 class ResponseMixin:
     """Response interface."""
 
-    def make_response(code, content):
+    def make_header(self, content):
+        """Build response headers."""
+        raise NotImplementedError()
+
+    def make_response(self, code, content):
         """Builds a response."""
         raise NotImplementedError()
 
-    def make_error_response(reason, message):
+    def make_error_response(self, reason, message):
         """Builds an error response."""
         raise abort(405)
 
@@ -32,17 +36,20 @@ class ItemResponse(ResponseMixin):
         """Constructor."""
         self.serializer = serializer
 
-    def make_response(code, content):
+    def make_response(self, code, content):
         """Builds a response for a single object."""
         # This should do the link building (e.g. sign posting):
         # self, pagination, query, etc.
         # In case of list responses, it would also take care of
         # extras such as aggregation.
-        make_response(
-            body=self.serializer.serialize_object(content),  # content is the object
-            status=code,
-            headers=self.make_header(),
+
+        # https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.make_response
+        # (body, status)
+        response = make_response(
+            self.serializer.serialize_object(content), code,  # content is the object
         )
+
+        return response
 
 
 class ListResponse(ResponseMixin):
@@ -55,14 +62,18 @@ class ListResponse(ResponseMixin):
         """Constructor."""
         self.serializer = serializer
 
-    def make_response(code, content):
+    def make_response(self, code, content):
         """Builds a response for a list of objects."""
         # This should do the link building (e.g. sign posting):
         # self, pagination, query, etc.
         # In case of list responses, it would also take care of
         # extras such as aggregation
-        make_response(
-            body=self.serializer.serialize_object(content),  # content is the object
-            response_code=code,
-            headers=self.make_header(),
+
+        # https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.make_response
+        # (body, status)
+        response = make_response(
+            self.serializer.serialize_object_list(content),  # content is the object
+            code,
         )
+
+        return response

--- a/flask_resources/response.py
+++ b/flask_resources/response.py
@@ -48,7 +48,7 @@ class ItemResponse(ResponseMixin):
         response = make_response(
             self.serializer.serialize_object(content), code,  # content is the object
         )
-
+        response.mimetype = "application/json"
         return response
 
 
@@ -76,4 +76,5 @@ class ListResponse(ResponseMixin):
             code,
         )
 
+        response.mimetype = "application/json"
         return response

--- a/flask_resources/response.py
+++ b/flask_resources/response.py
@@ -7,7 +7,7 @@
 
 """Response module."""
 
-from flask import make_response
+from flask import abort, make_response
 
 
 class ResponseMixin:
@@ -19,7 +19,7 @@ class ResponseMixin:
 
     def make_error_response(reason, message):
         """Builds an error response."""
-        raise NotImplementedError()
+        raise abort(405)
 
 
 class ItemResponse(ResponseMixin):
@@ -34,8 +34,10 @@ class ItemResponse(ResponseMixin):
 
     def make_response(code, content):
         """Builds a response for a single object."""
-        # This should do the link building (e.g. sign posting): self, pagination, query, etc.
-        # In case of list responses, it would also take care of extras such as aggregation
+        # This should do the link building (e.g. sign posting):
+        # self, pagination, query, etc.
+        # In case of list responses, it would also take care of
+        # extras such as aggregation.
         make_response(
             body=self.serializer.serialize_object(content),  # content is the object
             status=code,
@@ -55,8 +57,10 @@ class ListResponse(ResponseMixin):
 
     def make_response(code, content):
         """Builds a response for a list of objects."""
-        # This should do the link building (e.g. sign posting): self, pagination, query, etc.
-        # In case of list responses, it would also take care of extras such as aggregation
+        # This should do the link building (e.g. sign posting):
+        # self, pagination, query, etc.
+        # In case of list responses, it would also take care of
+        # extras such as aggregation
         make_response(
             body=self.serializer.serialize_object(content),  # content is the object
             response_code=code,

--- a/flask_resources/serializers/__init__.py
+++ b/flask_resources/serializers/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Flask-Resources is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Serializers."""
+
+from .serializers import SerializableMixin, SerializerMixin
+
+__all__ = ("SerializableMixin", "SerializerMixin")

--- a/flask_resources/serializers/__init__.py
+++ b/flask_resources/serializers/__init__.py
@@ -7,6 +7,7 @@
 
 """Serializers."""
 
+from .json import JSONSerializer
 from .serializers import SerializableMixin, SerializerMixin
 
-__all__ = ("SerializableMixin", "SerializerMixin")
+__all__ = ("JSONSerializer", "SerializableMixin", "SerializerMixin")

--- a/flask_resources/serializers/json.py
+++ b/flask_resources/serializers/json.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Flask-Resources is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""JSON serializer."""
+
+import json
+
+from .serializers import SerializerMixin
+
+
+class JSONSerializer(SerializerMixin):
+    """JSON serializer implementation."""
+
+    def serialize_object(self, object, response_ctx, *args, **kwargs):
+        """Dump the object into a json string."""
+        return json.dumps(object)
+
+    def serialize_object_list(self, object_list, response_ctx, *args, **kwargs):
+        """Dump the object list into a json string."""
+        return json.dumps(object_list)

--- a/flask_resources/serializers/json.py
+++ b/flask_resources/serializers/json.py
@@ -15,10 +15,10 @@ from .serializers import SerializerMixin
 class JSONSerializer(SerializerMixin):
     """JSON serializer implementation."""
 
-    def serialize_object(self, object, response_ctx, *args, **kwargs):
+    def serialize_object(self, object, response_ctx=None, *args, **kwargs):
         """Dump the object into a json string."""
         return json.dumps(object)
 
-    def serialize_object_list(self, object_list, response_ctx, *args, **kwargs):
+    def serialize_object_list(self, object_list, response_ctx=None, *args, **kwargs):
         """Dump the object list into a json string."""
         return json.dumps(object_list)

--- a/flask_resources/serializers/serializers.py
+++ b/flask_resources/serializers/serializers.py
@@ -5,7 +5,7 @@
 # Flask-Resources is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-"""Serializers and required interfaces."""
+"""Serializers required interfaces."""
 
 
 class SerializableMixin:

--- a/flask_resources/serializers/serializers.py
+++ b/flask_resources/serializers/serializers.py
@@ -10,7 +10,7 @@
 
 class SerializableMixin:
     """Serializable Interface.
-    
+
     Objects that will be serialized must implement it.
     """
 
@@ -40,14 +40,14 @@ class SerializerMixin:
 
     def serialize_object(self, object, response_ctx, *args, **kwargs):
         """Serialize a single object according to the response ctx.
-        
+
         The object type must implement ``SerializableMixin``.
         """
         raise NotImplementedError()
 
     def serialize_object_list(self, object_list, response_ctx, *args, **kwargs):
         """Serialize a list of objects according to the response ctx.
-        
+
         Each object type of the list should implement ``SerializableMixin``.
         """
         raise NotImplementedError()

--- a/flask_resources/serializers/serializers.py
+++ b/flask_resources/serializers/serializers.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Flask-Resources is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Serializers and required interfaces."""
+
+
+class SerializableMixin:
+    """Serializable Interface.
+    
+    Objects that will be serialized must implement it.
+    """
+
+    @property
+    def object():
+        """Returns the object itself."""
+        raise NotImplementedError()
+
+    @property
+    def id():
+        """Returns the object id."""
+        raise NotImplementedError()
+
+    @property
+    def version():
+        """Returns the object version or revision."""
+        raise NotImplementedError()
+
+    @property
+    def last_modified():
+        """Returns the date of the last modification."""
+        raise NotImplementedError()
+
+
+class SerializerMixin:
+    """Serializer Interface."""
+
+    def serialize_object(self, object, response_ctx, *args, **kwargs):
+        """Serialize a single object according to the response ctx.
+        
+        The object type must implement ``SerializableMixin``.
+        """
+        raise NotImplementedError()
+
+    def serialize_object_list(self, object_list, response_ctx, *args, **kwargs):
+        """Serialize a list of objects according to the response ctx.
+        
+        Each object type of the list should implement ``SerializableMixin``.
+        """
+        raise NotImplementedError()
+
+    def serialize_error(self, error, response_ctx, *args, **kwargs):
+        """Serialize an error reponse according to the response ctx."""
+        raise NotImplementedError()

--- a/flask_resources/serializers/serializers.py
+++ b/flask_resources/serializers/serializers.py
@@ -38,20 +38,20 @@ class SerializableMixin:
 class SerializerMixin:
     """Serializer Interface."""
 
-    def serialize_object(self, object, response_ctx, *args, **kwargs):
+    def serialize_object(self, object, response_ctx=None, *args, **kwargs):
         """Serialize a single object according to the response ctx.
 
         The object type must implement ``SerializableMixin``.
         """
         raise NotImplementedError()
 
-    def serialize_object_list(self, object_list, response_ctx, *args, **kwargs):
+    def serialize_object_list(self, object_list, response_ctx=None, *args, **kwargs):
         """Serialize a list of objects according to the response ctx.
 
         Each object type of the list should implement ``SerializableMixin``.
         """
         raise NotImplementedError()
 
-    def serialize_error(self, error, response_ctx, *args, **kwargs):
+    def serialize_error(self, error, response_ctx=None, *args, **kwargs):
         """Serialize an error reponse according to the response ctx."""
         raise NotImplementedError()

--- a/flask_resources/views/base.py
+++ b/flask_resources/views/base.py
@@ -23,7 +23,7 @@ class BaseView(MethodView):
     with_context_decorator = True
     """Flag to control resource context pushing decorator."""
 
-    def __init__(self, resource, response_handler, *args, **kwargs):
+    def __init__(self, resource, *args, **kwargs):
         """Constructor."""
         super(BaseView, self).__init__(*args, **kwargs)
         self.resource = resource

--- a/flask_resources/views/base.py
+++ b/flask_resources/views/base.py
@@ -23,7 +23,7 @@ class BaseView(MethodView):
     with_context_decorator = True
     """Flag to control resource context pushing decorator."""
 
-    def __init__(self, resource, *args, **kwargs):
+    def __init__(self, resource, response_handler, *args, **kwargs):
         """Constructor."""
         super(BaseView, self).__init__(*args, **kwargs)
         self.resource = resource

--- a/flask_resources/views/collections.py
+++ b/flask_resources/views/collections.py
@@ -13,7 +13,7 @@ from ..args.parsers import (
     search_request_parser,
 )
 from ..content_negotiation import content_negotiation
-from ..context import resource_requestctx, with_resource_requestctx
+from ..context import resource_requestctx
 from .base import BaseView
 
 
@@ -31,8 +31,6 @@ class ListView(BaseView):
         self.response_handlers = self.resource.config.list_response_handlers
         self.request_loaders = self.resource.config.item_request_loaders
 
-    @with_resource_requestctx
-    @content_negotiation
     def get(self, *args, **kwargs):
         """Search the collection."""
         resource_requestctx.request_args = self.search_parser.parse()
@@ -40,8 +38,6 @@ class ListView(BaseView):
 
         return _response_handler.make_response(*self.resource.search(*args, **kwargs))
 
-    @with_resource_requestctx
-    @content_negotiation
     def post(self, *args, **kwargs):
         """Create an item in the collection."""
         resource_requestctx.request_args = self.create_parser.parse()
@@ -67,16 +63,12 @@ class ItemView(BaseView):
         self.response_handlers = self.resource.config.item_response_handlers
         self.request_loaders = self.resource.config.item_request_loaders
 
-    @with_resource_requestctx
-    @content_negotiation
     def get(self, *args, **kwargs):
         """Get."""
         _response_handler = self.response_handlers[resource_requestctx.accept_mimetype]
 
         return _response_handler.make_response(*self.resource.read(*args, **kwargs))
 
-    @with_resource_requestctx
-    @content_negotiation
     def put(self, *args, **kwargs):
         """Put."""
         _response_handler = self.response_handlers[resource_requestctx.accept_mimetype]
@@ -87,8 +79,6 @@ class ItemView(BaseView):
             *self.resource.update(data, *args, **kwargs)
         )
 
-    @with_resource_requestctx
-    @content_negotiation
     def patch(self, *args, **kwargs):
         """Patch."""
         _response_handler = self.response_handlers[resource_requestctx.accept_mimetype]
@@ -99,8 +89,6 @@ class ItemView(BaseView):
             *self.resource.partial_update(data, *args, **kwargs)
         )
 
-    @with_resource_requestctx
-    @content_negotiation
     def delete(self, *args, **kwargs):
         """Delete."""
         _response_handler = self.response_handlers[resource_requestctx.accept_mimetype]

--- a/flask_resources/views/collections.py
+++ b/flask_resources/views/collections.py
@@ -30,16 +30,19 @@ class ListView(BaseView):
         # However there is no default config in flask-resources
         self.search_parser = self.resource.config.search_request_parser
         self.create_parser = self.resource.config.create_request_parser
+        self.response_handler = self.resource.config.list_response_handler
 
     def get(self, *args, **kwargs):
         """Search the collection."""
         resource_requestctx.request_args = self.search_parser.parse()
-        return self.resource.search()
+
+        self.response_handler.make_response(self.resource.search())
 
     def post(self, *args, **kwargs):
         """Create an item in the collection."""
         resource_requestctx.request_args = self.create_parser.parse()
-        return self.resource.create()
+
+        self.response_handler.make_response(self.resource.create())
 
 
 class ItemView(BaseView):
@@ -52,19 +55,20 @@ class ItemView(BaseView):
         """Constructor."""
         super(ItemView, self).__init__(*args, **kwargs)
         self.item_parser = self.resource.config.item_request_parser
+        self.response_handler = self.resource.config.item_response_handler
 
     def get(self, *args, **kwargs):
         """Get."""
-        return self.resource.read()
+        self.response_handler.make_response(self.resource.read())
 
     def put(self, *args, **kwargs):
         """Put."""
-        return self.resource.update()
+        self.response_handler.make_response(self.resource.update())
 
     def patch(self, *args, **kwargs):
         """Patch."""
-        return self.resource.partial_update()
+        self.response_handler.make_response(self.resource.partial_update())
 
     def delete(self, *args, **kwargs):
         """Delete."""
-        return self.resource.delete()
+        self.response_handler.make_response(self.resource.delete())

--- a/flask_resources/views/collections.py
+++ b/flask_resources/views/collections.py
@@ -12,7 +12,7 @@ from ..args.parsers import (
     item_request_parser,
     search_request_parser,
 )
-from ..context import resource_requestctx
+from ..context import resource_requestctx, with_resource_requestctx
 from .base import BaseView
 
 
@@ -27,19 +27,32 @@ class ListView(BaseView):
         super(ListView, self).__init__(*args, **kwargs)
         self.search_parser = self.resource.config.search_request_parser
         self.create_parser = self.resource.config.create_request_parser
-        self.response_handler = self.resource.config.list_response_handler
+        self.response_handler = self.resource.config.list_response_handlers
+        self.request_loaders = self.resource.config.item_request_loaders
 
+    @with_resource_requestctx
     def get(self, *args, **kwargs):
         """Search the collection."""
         resource_requestctx.request_args = self.search_parser.parse()
+        # FIXME: This selection should come from the request context
+        # along with content negotiation (fail fast if not supported)
+        _response_handler = self.response_handler["application/json"]
 
-        self.response_handler.make_response(self.resource.search())
+        return _response_handler.make_response(*self.resource.search(*args, **kwargs))
 
+    @with_resource_requestctx
     def post(self, *args, **kwargs):
         """Create an item in the collection."""
         resource_requestctx.request_args = self.create_parser.parse()
+        # FIXME: This selection should come from the request context
+        # along with content negotiation (fail fast if not supported)
+        _response_handler = self.response_handler["application/json"]
+        _response_loader = self.request_loaders["application/json"]
 
-        self.response_handler.make_response(self.resource.create())
+        data = _response_loader.load_request()
+        return _response_handler.make_response(
+            *self.resource.create(data, *args, **kwargs)
+        )
 
 
 class ItemView(BaseView):
@@ -52,21 +65,51 @@ class ItemView(BaseView):
         """Constructor."""
         super(ItemView, self).__init__(*args, **kwargs)
         self.item_parser = self.resource.config.item_request_parser
-        self.response_handler = self.resource.config.item_response_handler
+        self.response_handler = self.resource.config.item_response_handlers
         self.request_loaders = self.resource.config.item_request_loaders
 
+    @with_resource_requestctx
     def get(self, *args, **kwargs):
         """Get."""
-        self.response_handler.make_response(self.resource.read())
+        # FIXME: This selection should come from the request context
+        # along with content negotiation (fail fast if not supported)
+        _response_handler = self.response_handler["application/json"]
+        _response_loader = self.request_loaders["application/json"]
 
+        return _response_handler.make_response(*self.resource.read(*args, **kwargs))
+
+    @with_resource_requestctx
     def put(self, *args, **kwargs):
         """Put."""
-        self.response_handler.make_response(self.resource.update())
+        # FIXME: This selection should come from the request context
+        # along with content negotiation (fail fast if not supported)
+        _response_handler = self.response_handler["application/json"]
+        _response_loader = self.request_loaders["application/json"]
 
+        data = _response_loader.load_request()
+        return _response_handler.make_response(
+            *self.resource.update(data, *args, **kwargs)
+        )
+
+    @with_resource_requestctx
     def patch(self, *args, **kwargs):
         """Patch."""
-        self.response_handler.make_response(self.resource.partial_update())
+        # FIXME: This selection should come from the request context
+        # along with content negotiation (fail fast if not supported)
+        _response_handler = self.response_handler["application/json"]
+        _response_loader = self.request_loaders["application/json+patch"]
 
+        data = _response_loader.load_request()
+        return _response_handler.make_response(
+            *self.resource.partial_update(data, *args, **kwargs)
+        )
+
+    @with_resource_requestctx
     def delete(self, *args, **kwargs):
         """Delete."""
-        self.response_handler.make_response(self.resource.delete())
+        # FIXME: This selection should come from the request context
+        # along with content negotiation (fail fast if not supported)
+        _response_handler = self.response_handler["application/json"]
+        _response_loader = self.request_loaders["application/json"]
+
+        return _response_handler.make_response(*self.resource.delete(*args, **kwargs))

--- a/flask_resources/views/collections.py
+++ b/flask_resources/views/collections.py
@@ -25,9 +25,6 @@ class ListView(BaseView):
     def __init__(self, *args, **kwargs):
         """Constructor."""
         super(ListView, self).__init__(*args, **kwargs)
-        # FIXME: Parsers here? It is a naming dependency on the resource
-        # config.
-        # However there is no default config in flask-resources
         self.search_parser = self.resource.config.search_request_parser
         self.create_parser = self.resource.config.create_request_parser
         self.response_handler = self.resource.config.list_response_handler
@@ -56,6 +53,7 @@ class ItemView(BaseView):
         super(ItemView, self).__init__(*args, **kwargs)
         self.item_parser = self.resource.config.item_request_parser
         self.response_handler = self.resource.config.item_response_handler
+        self.request_loaders = self.resource.config.item_request_loaders
 
     def get(self, *args, **kwargs):
         """Get."""

--- a/flask_resources/views/collections.py
+++ b/flask_resources/views/collections.py
@@ -12,6 +12,7 @@ from ..args.parsers import (
     item_request_parser,
     search_request_parser,
 )
+from ..content_negotiation import content_negotiation
 from ..context import resource_requestctx, with_resource_requestctx
 from .base import BaseView
 
@@ -27,27 +28,25 @@ class ListView(BaseView):
         super(ListView, self).__init__(*args, **kwargs)
         self.search_parser = self.resource.config.search_request_parser
         self.create_parser = self.resource.config.create_request_parser
-        self.response_handler = self.resource.config.list_response_handlers
+        self.response_handlers = self.resource.config.list_response_handlers
         self.request_loaders = self.resource.config.item_request_loaders
 
     @with_resource_requestctx
+    @content_negotiation
     def get(self, *args, **kwargs):
         """Search the collection."""
         resource_requestctx.request_args = self.search_parser.parse()
-        # FIXME: This selection should come from the request context
-        # along with content negotiation (fail fast if not supported)
-        _response_handler = self.response_handler["application/json"]
+        _response_handler = self.response_handlers[resource_requestctx.accept_mimetype]
 
         return _response_handler.make_response(*self.resource.search(*args, **kwargs))
 
     @with_resource_requestctx
+    @content_negotiation
     def post(self, *args, **kwargs):
         """Create an item in the collection."""
         resource_requestctx.request_args = self.create_parser.parse()
-        # FIXME: This selection should come from the request context
-        # along with content negotiation (fail fast if not supported)
-        _response_handler = self.response_handler["application/json"]
-        _response_loader = self.request_loaders["application/json"]
+        _response_handler = self.response_handlers[resource_requestctx.accept_mimetype]
+        _response_loader = self.request_loaders[resource_requestctx.payload_mimetype]
 
         data = _response_loader.load_request()
         return _response_handler.make_response(
@@ -65,26 +64,23 @@ class ItemView(BaseView):
         """Constructor."""
         super(ItemView, self).__init__(*args, **kwargs)
         self.item_parser = self.resource.config.item_request_parser
-        self.response_handler = self.resource.config.item_response_handlers
+        self.response_handlers = self.resource.config.item_response_handlers
         self.request_loaders = self.resource.config.item_request_loaders
 
     @with_resource_requestctx
+    @content_negotiation
     def get(self, *args, **kwargs):
         """Get."""
-        # FIXME: This selection should come from the request context
-        # along with content negotiation (fail fast if not supported)
-        _response_handler = self.response_handler["application/json"]
-        _response_loader = self.request_loaders["application/json"]
+        _response_handler = self.response_handlers[resource_requestctx.accept_mimetype]
 
         return _response_handler.make_response(*self.resource.read(*args, **kwargs))
 
     @with_resource_requestctx
+    @content_negotiation
     def put(self, *args, **kwargs):
         """Put."""
-        # FIXME: This selection should come from the request context
-        # along with content negotiation (fail fast if not supported)
-        _response_handler = self.response_handler["application/json"]
-        _response_loader = self.request_loaders["application/json"]
+        _response_handler = self.response_handlers[resource_requestctx.accept_mimetype]
+        _response_loader = self.request_loaders[resource_requestctx.payload_mimetype]
 
         data = _response_loader.load_request()
         return _response_handler.make_response(
@@ -92,12 +88,11 @@ class ItemView(BaseView):
         )
 
     @with_resource_requestctx
+    @content_negotiation
     def patch(self, *args, **kwargs):
         """Patch."""
-        # FIXME: This selection should come from the request context
-        # along with content negotiation (fail fast if not supported)
-        _response_handler = self.response_handler["application/json"]
-        _response_loader = self.request_loaders["application/json+patch"]
+        _response_handler = self.response_handlers[resource_requestctx.accept_mimetype]
+        _response_loader = self.request_loaders[resource_requestctx.payload_mimetype]
 
         data = _response_loader.load_request()
         return _response_handler.make_response(
@@ -105,11 +100,9 @@ class ItemView(BaseView):
         )
 
     @with_resource_requestctx
+    @content_negotiation
     def delete(self, *args, **kwargs):
         """Delete."""
-        # FIXME: This selection should come from the request context
-        # along with content negotiation (fail fast if not supported)
-        _response_handler = self.response_handler["application/json"]
-        _response_loader = self.request_loaders["application/json"]
+        _response_handler = self.response_handlers[resource_requestctx.accept_mimetype]
 
         return _response_handler.make_response(*self.resource.delete(*args, **kwargs))

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,7 +8,7 @@
 
 pydocstyle flask_resources tests docs && \
 isort --multi-line=3 --line-width=88 --trailing-comma --force-grid-wrap=0 --use-parentheses -rc -c -df && \
-black --check --diff flask_resources && \
+black --check --diff flask_resources tests && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 pytest

--- a/setup.py
+++ b/setup.py
@@ -15,17 +15,12 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "check-manifest>=0.25",
-    "coverage>=4.0",
-    "isort>=4.3.3",
-    "pydocstyle>=2.0.0",
-    "pytest-cov>=2.5.1",
-    "pytest-pep8>=1.0.6",
+    "pytest-invenio>=1.3.2",
     "black>=19.10b0",
 ]
 
 extras_require = {
-    "docs": ["Sphinx>=1.5.1",],
+    "docs": ["Sphinx>=1.5.1,<3",],
     "tests": tests_require,
 }
 
@@ -33,10 +28,7 @@ extras_require["all"] = []
 for reqs in extras_require.values():
     extras_require["all"].extend(reqs)
 
-setup_requires = [
-    "Babel>=1.3",
-    "pytest-runner>=3.0.0,<5",
-]
+setup_requires = ["Babel>=1.3"]
 
 install_requires = [
     "Flask~=1.1.2",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,15 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-invenio>=1.3.2",
+    'check-manifest>=0.25',
+    # coverage pinned because of https://github.com/nedbat/coveragepy/issues/716
+    'coverage>=4.0,<5.0.0',
+    'isort>=4.3',
+    'pytest>=4.6.1',
+    'pytest-cov>=2.5.1',
+    'pytest-flask>=0.15.1,<1.0.0',
+    'pytest-pep8>=1.0.6',
+    "pydocstyle~=5.0.0",
     "black>=19.10b0",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,16 +48,10 @@ class CustomResource(CollectionResource):
 
 
 @pytest.fixture(scope="module")
-def create_app(instance_path):
+def app():
     """Application factory fixture."""
+    app_ = Flask(__name__)
+    bp = CustomResource().as_blueprint("custom_resource")
+    app_.register_blueprint(bp)
 
-    def app(*args, **kwargs):
-        """Create app."""
-        app_ = Flask(__name__)
-
-        bp = CustomResource().as_blueprint("custom_resource")
-        app_.register_blueprint(bp)
-
-        return app_
-
-    return app
+    return app_

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ class CustomResource(CollectionResource):
 
         return 200, resp
 
-    def create(self, data):
+    def create(self, obj):
         """Create."""
         self.db[obj["id"]] = obj["content"]
 
@@ -44,7 +44,7 @@ class CustomResource(CollectionResource):
 
     def read(self, id):
         """Read."""
-        return 200, self.db[id]
+        return 200, {"id": id, "content": self.db[id]}
 
 
 @pytest.fixture(scope="module")
@@ -55,7 +55,7 @@ def create_app(instance_path):
         """Create app."""
         app_ = Flask(__name__)
 
-        bp = CustomResource().as_blueprint()
+        bp = CustomResource().as_blueprint("custom_resource")
         app_.register_blueprint(bp)
 
         return app_

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,52 @@ import pytest
 from flask import Flask
 
 
+class CustomSerializer(SerializerMixin):
+    """Custom serializer implementation."""
+
+    def serialize_object(self, object, response_ctx, *args, **kwargs):
+        """Custom object serialization."""
+        pass
+
+    def serialize_object_list(self, object_list, response_ctx, *args, **kwargs):
+        """Custom object list serialization."""
+        pass
+
+
+class CustomResourceConfig:
+    """Custom resource configuration."""
+
+    item_handlers = {"application/json": ItemResponse(CustomSerializer)}
+
+
+class CustomResource(CollectionResource):
+    """Custom resource implementation."""
+
+    def search(self, request_context):
+        """Search."""
+        pass
+
+    def create(self):
+        """Create."""
+        pass
+
+    def read(self, id, *args, **kwargs):
+        """Read."""
+        pass
+
+    def update(self, data, *args, **kwargs):
+        """Update."""
+        pass
+
+    def partial_update(self, data, *args, **kwargs):
+        """Partial update."""
+        pass
+
+    def delete(self, *args, **kwargs):
+        """Delete."""
+        pass
+
+
 @pytest.fixture(scope="module")
 def create_app(instance_path):
     """Application factory fixture."""
@@ -26,3 +72,9 @@ def create_app(instance_path):
         return app_
 
     return app
+
+
+@pytest.fixture(scope="module")
+def custom_resource_config():
+    """Returns a simple custom resource with a custom configuration."""
+    return CustomResource(config=CustomResourceConfig)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,23 +14,7 @@ fixtures are available.
 import pytest
 from flask import Flask
 
-
-class CustomSerializer(SerializerMixin):
-    """Custom serializer implementation."""
-
-    def serialize_object(self, object, response_ctx, *args, **kwargs):
-        """Custom object serialization."""
-        pass
-
-    def serialize_object_list(self, object_list, response_ctx, *args, **kwargs):
-        """Custom object list serialization."""
-        pass
-
-
-class CustomResourceConfig:
-    """Custom resource configuration."""
-
-    item_handlers = {"application/json": ItemResponse(CustomSerializer)}
+from flask_resources.resources import CollectionResource
 
 
 class CustomResource(CollectionResource):
@@ -77,4 +61,4 @@ def create_app(instance_path):
 @pytest.fixture(scope="module")
 def custom_resource_config():
     """Returns a simple custom resource with a custom configuration."""
-    return CustomResource(config=CustomResourceConfig)
+    return CustomResource()

--- a/tests/test_content_negotiation.py
+++ b/tests/test_content_negotiation.py
@@ -16,22 +16,20 @@ from flask_resources.content_negotiation import ContentNegotiator
 # NOTE: By scoping down we remove the need to check for HTTP method
 def test_choose_provided_and_accepted_mimetype():
     # Should choose mimetype that is accepted by client and served by server
-    server_mimetypes = ['application/json', 'application/marcxml+xml']
+    server_mimetypes = ["application/json", "application/marcxml+xml"]
     client_mimetypes = parse_accept_header(
-        'text/plain,application/json,*/*',
-        MIMEAccept
+        "text/plain,application/json,*/*", MIMEAccept
     )
 
-    assert 'application/json' == ContentNegotiator.match_by_accept(
+    assert "application/json" == ContentNegotiator.match_by_accept(
         server_mimetypes, client_mimetypes
     )
 
     client_mimetypes = parse_accept_header(
-        'text/plain,application/marcxml+xml,*/*',
-        MIMEAccept
+        "text/plain,application/marcxml+xml,*/*", MIMEAccept
     )
 
-    assert 'application/marcxml+xml' == ContentNegotiator.match_by_accept(
+    assert "application/marcxml+xml" == ContentNegotiator.match_by_accept(
         server_mimetypes, client_mimetypes
     )
 
@@ -39,74 +37,62 @@ def test_choose_provided_and_accepted_mimetype():
 def test_favour_specificity_over_quality():
     # favour more specific but lower quality mimetype over
     # less specific (e.g. wildcard) but higher quality
-    server_mimetypes = ['application/json', 'application/marcxml+xml']
+    server_mimetypes = ["application/json", "application/marcxml+xml"]
     client_mimetypes = parse_accept_header(
-        'text/plain, application/json;q=0.5, */*',
-        MIMEAccept
+        "text/plain, application/json;q=0.5, */*", MIMEAccept
     )
 
-    assert 'application/json' == ContentNegotiator.match_by_accept(
+    assert "application/json" == ContentNegotiator.match_by_accept(
         server_mimetypes, client_mimetypes
     )
 
 
 def test_favour_quality_over_same_specificity():
-    server_mimetypes = ['application/json', 'application/marcxml+xml']
+    server_mimetypes = ["application/json", "application/marcxml+xml"]
     client_mimetypes = parse_accept_header(
-        'application/json;q=0.5, application/marcxml+xml',
-        MIMEAccept
+        "application/json;q=0.5, application/marcxml+xml", MIMEAccept
     )
 
-    assert 'application/marcxml+xml' == ContentNegotiator.match_by_accept(
+    assert "application/marcxml+xml" == ContentNegotiator.match_by_accept(
         server_mimetypes, client_mimetypes
     )
 
     client_mimetypes = parse_accept_header(
-        'application/marcxml+xml;q=0.4, application/json;q=0.6',
-        MIMEAccept
+        "application/marcxml+xml;q=0.4, application/json;q=0.6", MIMEAccept
     )
 
-    assert 'application/json' == ContentNegotiator.match_by_accept(
+    assert "application/json" == ContentNegotiator.match_by_accept(
         server_mimetypes, client_mimetypes
     )
 
 
 def test_choose_default_if_no_match_and_wildcard_accepted():
     # choose default if no match and client accepts wildcard
-    server_mimetypes = ['application/json', 'application/marcxml+xml']
-    client_mimetypes = parse_accept_header(
-        'text/plain,*/*',
-        MIMEAccept
-    )
+    server_mimetypes = ["application/json", "application/marcxml+xml"]
+    client_mimetypes = parse_accept_header("text/plain,*/*", MIMEAccept)
 
-    assert 'application/json' == ContentNegotiator.match_by_accept(
-        server_mimetypes, client_mimetypes, default='application/json'
+    assert "application/json" == ContentNegotiator.match_by_accept(
+        server_mimetypes, client_mimetypes, default="application/json"
     )
 
 
 def test_choose_none_if_no_match_and_wildcard_not_accepted():
-    server_mimetypes = ['application/json', 'application/marcxml+xml']
-    client_mimetypes = parse_accept_header(
-        'text/plain',
-        MIMEAccept
-    )
+    server_mimetypes = ["application/json", "application/marcxml+xml"]
+    client_mimetypes = parse_accept_header("text/plain", MIMEAccept)
 
     mime_type = ContentNegotiator.match_by_accept(
-        server_mimetypes, client_mimetypes, default='application/json'
+        server_mimetypes, client_mimetypes, default="application/json"
     )
 
     assert mime_type is None
 
 
 def test_choose_default_if_nothing_accepted():
-    server_mimetypes = ['application/json', 'application/marcxml+xml']
-    client_mimetypes = parse_accept_header(
-        '',
-        MIMEAccept
-    )
+    server_mimetypes = ["application/json", "application/marcxml+xml"]
+    client_mimetypes = parse_accept_header("", MIMEAccept)
 
-    assert 'application/json' == ContentNegotiator.match_by_accept(
-        server_mimetypes, client_mimetypes, default='application/json'
+    assert "application/json" == ContentNegotiator.match_by_accept(
+        server_mimetypes, client_mimetypes, default="application/json"
     )
 
 
@@ -114,20 +100,20 @@ def test_choose_default_if_nothing_accepted():
 # NOTE: By scoping down we remove the need to check for HTTP method
 def test_choose_query_mimetype():
     formats_map = {
-        'json': 'application/json',
-        'marcxml': 'application/marcxml+xml',
+        "json": "application/json",
+        "marcxml": "application/marcxml+xml",
     }
-    fmt = 'marcxml'  # this is the query
+    fmt = "marcxml"  # this is the query
 
-    assert 'application/marcxml+xml' == ContentNegotiator.match_by_format(
-        formats_map, fmt)
+    assert "application/marcxml+xml" == ContentNegotiator.match_by_format(
+        formats_map, fmt
+    )
 
-    fmt = 'json'
+    fmt = "json"
 
-    assert 'application/json' == ContentNegotiator.match_by_format(
-        formats_map, fmt)
+    assert "application/json" == ContentNegotiator.match_by_format(formats_map, fmt)
 
-    fmt = 'foo'
+    fmt = "foo"
 
     mime_type = ContentNegotiator.match_by_format(formats_map, fmt)
 
@@ -136,69 +122,56 @@ def test_choose_query_mimetype():
 
 # Test top-level ContentNegotiator.match
 def test_favour_query_mimetype_over_header_mimetype():
-    server_mimetypes = ['application/json', 'application/marcxml+xml']
-    client_mimetypes = parse_accept_header(
-        'application/json',
-        MIMEAccept
-    )
+    server_mimetypes = ["application/json", "application/marcxml+xml"]
+    client_mimetypes = parse_accept_header("application/json", MIMEAccept)
     formats_map = {
-        'json': 'application/json',
-        'marcxml': 'application/marcxml+xml',
+        "json": "application/json",
+        "marcxml": "application/marcxml+xml",
     }
-    fmt = 'marcxml'
+    fmt = "marcxml"
 
-    assert 'application/marcxml+xml' == ContentNegotiator.match(
+    assert "application/marcxml+xml" == ContentNegotiator.match(
         server_mimetypes, client_mimetypes, formats_map, fmt
     )
 
-    client_mimetypes = parse_accept_header(
-        'application/marcxml+xml',
-        MIMEAccept
-    )
-    fmt = 'json'
+    client_mimetypes = parse_accept_header("application/marcxml+xml", MIMEAccept)
+    fmt = "json"
 
-    assert 'application/json' == ContentNegotiator.match(
+    assert "application/json" == ContentNegotiator.match(
         server_mimetypes, client_mimetypes, formats_map, fmt
     )
 
 
 def test_favour_header_mimetype_if_no_query_mimetype():
-    server_mimetypes = ['application/json', 'application/marcxml+xml']
-    client_mimetypes = parse_accept_header(
-        'application/json',
-        MIMEAccept
-    )
+    server_mimetypes = ["application/json", "application/marcxml+xml"]
+    client_mimetypes = parse_accept_header("application/json", MIMEAccept)
     formats_map = {
-        'json': 'application/json',
-        'marcxml': 'application/marcxml+xml',
+        "json": "application/json",
+        "marcxml": "application/marcxml+xml",
     }
     fmt = None
 
-    assert 'application/json' == ContentNegotiator.match(
+    assert "application/json" == ContentNegotiator.match(
         server_mimetypes, client_mimetypes, formats_map, fmt
     )
 
     formats_map = {}
-    fmt = 'marcxml'
+    fmt = "marcxml"
 
-    assert 'application/json' == ContentNegotiator.match(
+    assert "application/json" == ContentNegotiator.match(
         server_mimetypes, client_mimetypes, formats_map, fmt
     )
 
 
 def test_choose_default_if_no_query_and_no_header():
-    server_mimetypes = ['application/json', 'application/marcxml+xml']
-    client_mimetypes = parse_accept_header(
-        '',
-        MIMEAccept
-    )
+    server_mimetypes = ["application/json", "application/marcxml+xml"]
+    client_mimetypes = parse_accept_header("", MIMEAccept)
     formats_map = {
-        'json': 'application/json',
-        'marcxml': 'application/marcxml+xml',
+        "json": "application/json",
+        "marcxml": "application/marcxml+xml",
     }
     fmt = None
 
-    assert 'application/json' == ContentNegotiator.match(
-        server_mimetypes, client_mimetypes, formats_map, fmt,
-        default='application/json'
+    assert "application/json" == ContentNegotiator.match(
+        server_mimetypes, client_mimetypes, formats_map, fmt, default="application/json"
     )

--- a/tests/test_flask_resources.py
+++ b/tests/test_flask_resources.py
@@ -1,6 +1,0 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright (C) 2020 CERN.
-#
-# Flask--Resources is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -8,12 +8,33 @@
 """Resources test module."""
 
 
-def test_custom_resource():
+def test_custom_resource(base_client):
     """Test the registration of a custom resource.
 
     It tests the registration process itself and the correct functioning
     of its endpoints.
     """
-    # bp = UserResource(config=ResourceConfig(), datastore).as_blueprint()
-    # app.register_blueprint(bp)
-    pass
+    # The resource returns a list, empty for now
+    resource_obj = base_client.get("/resources/")
+    assert resource_obj.status_code == 200
+    assert len(resource_obj.get_json) == 0
+
+    # Create a resource object
+    obj_content = {"id": "1234-ABDC", "content": "test resource obj content"}
+    resource_obj = base_client.post("/resources/", body=obj_content)
+    assert resource_obj.status_code == 201
+
+    # Search for the previously created obj
+    resource_obj = base_client.get("/resources/")
+    assert resource_obj.status_code == 200
+
+    resource_obj_json = resource_obj.get_json()
+    assert len(resource_obj.data) == 1
+    assert resource_obj_json[0]["id"] == "1234-ABCD"
+
+    # Get the previously created obj
+    resource_obj = base_client.get("/resources/1234-ABDC")
+    assert resource_obj.status_code == 200
+
+    resource_obj_json = resource_obj.get_json()
+    assert resource_obj_json["id"] == "1234-ABCD"

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -10,7 +10,7 @@
 import json
 
 
-def test_custom_resource(base_client):
+def test_custom_resource(client):
     """Test the registration of a custom resource.
 
     It tests the registration process itself and the correct functioning
@@ -19,27 +19,23 @@ def test_custom_resource(base_client):
     headers = {"content-type": "application/json", "accept": "application/json"}
 
     # The resource returns a list, empty for now
-    resource_obj = base_client.get("/resources/", headers=headers)
+    resource_obj = client.get("/resources/", headers=headers)
     assert resource_obj.status_code == 200
-    assert len(resource_obj.get_json()) == 0
+    assert len(resource_obj.json) == 0
 
     # Create a resource object
     obj_content = {"id": "1234-ABCD", "content": "test resource obj content"}
     obj_json = json.dumps(obj_content)
-    resource_obj = base_client.post("/resources/", data=obj_json, headers=headers)
+    resource_obj = client.post("/resources/", data=obj_json, headers=headers)
     assert resource_obj.status_code == 201
 
     # Search for the previously created obj
-    resource_obj = base_client.get("/resources/", headers=headers)
+    resource_obj = client.get("/resources/", headers=headers)
     assert resource_obj.status_code == 200
-
-    resource_obj_json = resource_obj.get_json()
-    assert len(resource_obj.get_json()) == 1
-    assert resource_obj_json[0]["id"] == "1234-ABCD"
+    assert len(resource_obj.json) == 1
+    assert resource_obj.json[0]["id"] == "1234-ABCD"
 
     # Get the previously created obj
-    resource_obj = base_client.get("/resources/1234-ABCD", headers=headers)
+    resource_obj = client.get("/resources/1234-ABCD", headers=headers)
     assert resource_obj.status_code == 200
-
-    resource_obj_json = resource_obj.get_json()
-    assert resource_obj_json["id"] == "1234-ABCD"
+    assert resource_obj.json["id"] == "1234-ABCD"

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -7,6 +7,8 @@
 
 """Resources test module."""
 
+import json
+
 
 def test_custom_resource(base_client):
     """Test the registration of a custom resource.
@@ -14,26 +16,29 @@ def test_custom_resource(base_client):
     It tests the registration process itself and the correct functioning
     of its endpoints.
     """
+    headers = {"content-type": "application/json", "accept": "application/json"}
+
     # The resource returns a list, empty for now
-    resource_obj = base_client.get("/resources/")
+    resource_obj = base_client.get("/resources/", headers=headers)
     assert resource_obj.status_code == 200
-    assert len(resource_obj.get_json) == 0
+    assert len(resource_obj.get_json()) == 0
 
     # Create a resource object
-    obj_content = {"id": "1234-ABDC", "content": "test resource obj content"}
-    resource_obj = base_client.post("/resources/", body=obj_content)
+    obj_content = {"id": "1234-ABCD", "content": "test resource obj content"}
+    obj_json = json.dumps(obj_content)
+    resource_obj = base_client.post("/resources/", data=obj_json, headers=headers)
     assert resource_obj.status_code == 201
 
     # Search for the previously created obj
-    resource_obj = base_client.get("/resources/")
+    resource_obj = base_client.get("/resources/", headers=headers)
     assert resource_obj.status_code == 200
 
     resource_obj_json = resource_obj.get_json()
-    assert len(resource_obj.data) == 1
+    assert len(resource_obj.get_json()) == 1
     assert resource_obj_json[0]["id"] == "1234-ABCD"
 
     # Get the previously created obj
-    resource_obj = base_client.get("/resources/1234-ABDC")
+    resource_obj = base_client.get("/resources/1234-ABCD", headers=headers)
     assert resource_obj.status_code == 200
 
     resource_obj_json = resource_obj.get_json()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Flask--Resources is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Resources test module."""
+
+
+def test_custom_resource():
+    """Test the registration of a custom resource.
+
+    It tests the registration process itself and the correct functioning
+    of its endpoints.
+    """
+    # bp = UserResource(config=ResourceConfig(), datastore).as_blueprint()
+    # app.register_blueprint(bp)
+    pass


### PR DESCRIPTION
Requires #16 
Closes #15 - Many record/invenio specific things have been moved to `invenio-resources`. See more at https://github.com/inveniosoftware/invenio-resources/issues/8.
Closes #4 - The resource class does not `abort` anymore. It returns the error code. How to treat it properlly needs to be addressed in #9 (see more below).

**Errors and serialization**
Note that the default resource returns a 405 code with no content and then the views call `make_response` by default. The default views are made to work with the resource test case (A.K.A. How would a user create an API with this). However, changes in this area are needed to:
1- Support the behaviour of the default resource, i.e. return a 405 forbidden error.
2- Do the distinction from error and successful response somewhere. Could we benefit from some other abstraction present in Flask/Other library?

This questions will and the whole error serialization will be treated separatelly in #3 

**Resources file hierarchy**

The `resource.py` currently contains the `Resource`, the `CollectionResource`, the `SingletonResource` and the `ResourceConfig` classes. Should they be separated into different files? If yes:
- In a `resources` folder?
- In the corresponding files of the `views` folder?

The answer will depend from and be treated in https://github.com/inveniosoftware/flask-resources/issues/18

**Naming** 🎊

The `SerializerMixin` uses the word `object`, which is reserved. Any suggestions for a change?