### PR TITLE
tests: serializers and loaders

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,12 @@ tests_require = [
     # coverage pinned because of https://github.com/nedbat/coveragepy/issues/716
     "coverage>=4.0,<5.0.0",
     "isort>=4.3",
+    "pydocstyle~=5.0.0",
     "pytest>=4.6.1",
     "pytest-cov>=2.5.1",
     "pytest-flask>=0.15.1,<1.0.0",
+    "pytest-mock>=1.6.0",
     "pytest-pep8>=1.0.6",
-    "pydocstyle~=5.0.0",
 ]
 
 extras_require = {

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Flask--Resources is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Loaders test module."""
+
+import json
+
+from flask import request
+
+from flask_resources.loaders import JSONLoader, JSONPatchLoader, LoaderMixin
+
+
+class CustomLoader(LoaderMixin):
+    """Custom loader implementation."""
+
+    def load_request(self, *args, **kwargs):
+        """Load the request."""
+        return request.get_data()
+
+
+def test_custom_loader(mocker):
+    """Test custom loader."""
+    request_body = {"field_one": "value", "field_two": "some other value"}
+
+    def get_data():
+        return str(request_body)
+
+    request_mock = mocker.patch("tests.test_loaders.request")
+    request_mock.get_data = get_data
+
+    loader = CustomLoader()
+    assert loader.load_request() == str(request_body)
+
+
+def test_json_loader(mocker):
+    """Test JSON loader."""
+    request_body = {"field_one": "value", "field_two": "some other value"}
+
+    def get_json():
+        return json.dumps(request_body)
+
+    request_mock = mocker.patch("flask_resources.loaders.json.request")
+    request_mock.get_json = get_json
+
+    loader = JSONLoader()
+    assert loader.load_request() == json.dumps(request_body)
+
+
+def test_json_patch_loader(mocker):
+    """Test JSON loader."""
+    request_body = {"op": "replace", "path": "/field_one", "value": "something patched"}
+
+    def get_json(force=None):
+        return json.dumps(request_body)
+
+    request_mock = mocker.patch("flask_resources.loaders.json.request")
+    request_mock.get_json = get_json
+
+    loader = JSONPatchLoader()
+    assert loader.load_request() == json.dumps(request_body)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Flask--Resources is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Serializers test module."""
+
+import json
+
+from werkzeug.exceptions import HTTPException
+
+from flask_resources.serializers import JSONSerializer, SerializerMixin
+
+
+class CustomSerializer(SerializerMixin):
+    """Custom serializer implementation."""
+
+    def serialize_object(self, object, response_ctx=None, *args, **kwargs):
+        """Dump the object into a json string."""
+        return object.get("content")
+
+    def serialize_object_list(self, object_list, response_ctx=None, *args, **kwargs):
+        """Dump the object list into a json string."""
+        return str([obj.get("content") for obj in object_list])
+
+    def serialize_error(self, error, response_ctx=None, *args, **kwargs):
+        """Serialize an error reponse according to the response ctx."""
+        # NOTE: In non-overwritten exceptions (i.e. coming from Werkzeug)
+        # `get_description` returns HTML tags.
+        return error.description
+
+
+def test_custom_serializer():
+    """Test custom serializer."""
+    serializer = CustomSerializer()
+
+    # Test a simple object
+    obj = {"id": "value", "content": "another value"}
+    assert serializer.serialize_object(obj) == obj.get("content")
+
+    # Test an object list
+    obj_list = [obj, obj, obj]
+    assert serializer.serialize_object_list(obj_list) == str(
+        [obj.get("content") for obj in obj_list]
+    )
+
+    # Test an exception
+    error = HTTPException()
+    assert serializer.serialize_error(error) == error.description
+
+
+def test_json_serializer():
+    """Test JSON serializer."""
+    serializer = JSONSerializer()
+
+    # Test a simple object
+    obj = {"field_one": "value", "field_two": "another value"}
+    assert serializer.serialize_object(obj) == json.dumps(obj)
+
+    # Test an object list
+    obj_list = [obj, obj, obj]
+    assert serializer.serialize_object_list(obj_list) == json.dumps(obj_list)
+
+    # Test an exception
+    error = HTTPException()
+    assert serializer.serialize_error(error) == json.dumps(error.description)


### PR DESCRIPTION
requires https://github.com/inveniosoftware/flask-resources/pull/21

adds tests for serializers and loaders:

- Some tests are ultra simple, even trivial.
- For now they might not test anything needed, because the complexity has not arrived yet.
- It is nice to have them so they evelove/force us to test the code when implementing changes/features.

Many other interfaces/classes still need testing.

Closes https://github.com/inveniosoftware/flask-resources/issues/11