### PR TITLE
several minor fixes

### DIFF
--- a/flask_resources/context.py
+++ b/flask_resources/context.py
@@ -47,8 +47,7 @@ class ResourceRequestCtx(object):
         self.accept_mimetype = accept_mimetype
         self.payload_mimetype = payload_mimetype  # Content-Type
         self.request_args = request_args
-        self.data = data
-        self.permission_acton = None  # FIXME: Unused at the moment
+        self.request_content = data
 
     def __enter__(self):
         """Push the resource context manager on the current request."""

--- a/flask_resources/deserializers/deserializers.py
+++ b/flask_resources/deserializers/deserializers.py
@@ -11,6 +11,6 @@
 class DeserializerMixin:
     """Deserializer Interface."""
 
-    def deserialize_object(self, obj, *args, **kwargs):
+    def deserialize_data(self, data, *args, **kwargs):
         """Deserializes an object."""
         raise NotImplementedError()

--- a/flask_resources/deserializers/json.py
+++ b/flask_resources/deserializers/json.py
@@ -15,6 +15,6 @@ from .deserializers import DeserializerMixin
 class JSONDeserializer(DeserializerMixin):
     """JSON Deserializer."""
 
-    def deserialize_object(self, obj, *args, **kwargs):
-        """Deserializes an object into json."""
-        return json.loads(obj)
+    def deserialize_data(self, data, *args, **kwargs):
+        """Deserializes the input data into json."""
+        return json.loads(data)

--- a/flask_resources/loaders.py
+++ b/flask_resources/loaders.py
@@ -42,13 +42,13 @@ class RequestLoader(LoaderMixin):
     def load_item_request(self, data=True, *args, **kwargs):
         """Build response headers."""
         if data:
-            resource_requestctx.request_content = self.deserializer.deserialize_object(
+            resource_requestctx.request_content = self.deserializer.deserialize_data(
                 request.data
             )
 
     def load_create_request(self, *args, **kwargs):
         """Load an item creation request."""
-        resource_requestctx.request_content = self.deserializer.deserialize_object(
+        resource_requestctx.request_content = self.deserializer.deserialize_data(
             request.data
         )
 

--- a/flask_resources/resources.py
+++ b/flask_resources/resources.py
@@ -17,9 +17,8 @@ from .response import ItemResponse, ListResponse
 from .serializers import JSONSerializer
 from .views import ItemView, ListView, SingletonView
 
-ITEM_VIEW_SUFFIX = "_item_view"
-LIST_VIEW_SUFFIX = "_list_view"
-SINGLETON_VIEW_SUFFIX = "_singleton_view"
+ITEM_VIEW_SUFFIX = "_item"
+LIST_VIEW_SUFFIX = "_list"
 
 
 class ResourceConfig:
@@ -39,17 +38,17 @@ class ResourceConfig:
 class Resource:
     """Resource controller interface."""
 
-    def __init__(self, config=ResourceConfig, *args, **kwargs):
+    def __init__(self, config=ResourceConfig):
         """Initialize the base resource."""
         self.config = config
         self.bp_name = None
 
     # Primary interface
-    def search(self, request_context):
+    def search(self, *args, **kwargs):
         """Perform a search over the items."""
         raise MethodNotAllowed()
 
-    def create(self):
+    def create(self, *args, **kwargs):
         """Create an item."""
         raise MethodNotAllowed()
 
@@ -86,7 +85,7 @@ class Resource:
             {
                 "rule": self.config.item_route,
                 "view_func": ItemView.as_view(
-                    name="{}{}".format(bp_name, ITEM_VIEW_SUFFIX), resource=self,
+                    name="{}".format(bp_name), resource=self,
                 ),
             }
         ]
@@ -126,7 +125,7 @@ class SingletonResource(Resource):
             {
                 "rule": self.config.list_route,
                 "view_func": SingletonView.as_view(
-                    name="{}{}".format(bp_name, SINGLETON_VIEW_SUFFIX), resource=self,
+                    name="{}".format(bp_name), resource=self,
                 ),
             }
         ]

--- a/flask_resources/response.py
+++ b/flask_resources/response.py
@@ -17,10 +17,7 @@ class ResponseMixin:
 
     def make_header(self, content=None):
         """Build response headers."""
-        return {
-            "content-type": resource_requestctx.payload_mimetype,
-            "accept": resource_requestctx.accept_mimetype,
-        }
+        return {"content-type": resource_requestctx.payload_mimetype}
 
     def make_response(self, code, content):
         """Builds a response."""
@@ -37,7 +34,7 @@ class ItemResponse(ResponseMixin):
     Builds up a reponse for a single object.
     """
 
-    def __init__(self, serializer=None, *args, **kwargs):
+    def __init__(self, serializer=None):
         """Constructor."""
         self.serializer = serializer
 
@@ -63,7 +60,7 @@ class ListResponse(ResponseMixin):
     Builds up a reponse for a list of objects.
     """
 
-    def __init__(self, serializer=None, *args, **kwargs):
+    def __init__(self, serializer=None):
         """Constructor."""
         self.serializer = serializer
 


### PR DESCRIPTION
Replaces: https://github.com/inveniosoftware/flask-resources/pull/26

Changes implemented by @lnielsen 

- Blueprint names: I would only add suffixes to blueprint names that have multiple endpoints (i.e. only collection).
- Resource. should take same parameters as the MethodView.get/put/post/patch/...
- Accept is only a request header, but not a response header.


Rises:

- Resource naming to `ResourceView`: #18 
- Error hanlding `try/catch` vs `error_hanlders` to be trated at #36 36
- Loaders should put data on the resource request context and not pass it as arguments: #38 
- Can MethodView.decorators be used in BaseView? #41 

Other changes:

- Renaming of `obj` by `data` in loaders logic

Closes https://github.com/inveniosoftware/flask-resources/issues/30
