### PR TITLE
content negotiation: refactor and remove hardcoded values

### DIFF
--- a/flask_resources/context.py
+++ b/flask_resources/context.py
@@ -47,8 +47,7 @@ class ResourceRequestCtx(object):
         self.accept_mimetype = accept_mimetype
         self.payload_mimetype = payload_mimetype  # Content-Type
         self.request_args = request_args
-        self.data = data
-        self.permission_acton = None  # FIXME: Unused at the moment
+        self.request_content = data
 
     def __enter__(self):
         """Push the resource context manager on the current request."""

--- a/flask_resources/context.py
+++ b/flask_resources/context.py
@@ -57,6 +57,11 @@ class ResourceRequestCtx(object):
         """Pop the resource context manager from the current request."""
         del g.resource_requestctx
 
+    def update(self, values):
+        """Update the context fields present in the received dictionary `values`."""
+        for field, value in values.items():
+            self.__setattr__(field, value)
+
 
 def with_resource_requestctx(f):
     """Wrap in resource request context."""

--- a/flask_resources/deserializers/deserializers.py
+++ b/flask_resources/deserializers/deserializers.py
@@ -11,6 +11,6 @@
 class DeserializerMixin:
     """Deserializer Interface."""
 
-    def deserialize_object(self, obj, *args, **kwargs):
+    def deserialize_data(self, data, *args, **kwargs):
         """Deserializes an object."""
         raise NotImplementedError()

--- a/flask_resources/deserializers/json.py
+++ b/flask_resources/deserializers/json.py
@@ -15,6 +15,6 @@ from .deserializers import DeserializerMixin
 class JSONDeserializer(DeserializerMixin):
     """JSON Deserializer."""
 
-    def deserialize_object(self, obj, *args, **kwargs):
-        """Deserializes an object into json."""
-        return json.loads(obj)
+    def deserialize_data(self, data, *args, **kwargs):
+        """Deserializes the input data into json."""
+        return json.loads(data)

--- a/flask_resources/loaders.py
+++ b/flask_resources/loaders.py
@@ -37,8 +37,8 @@ class RequestLoader(LoaderMixin):
 
     def load_item_request(self, *args, **kwargs):
         """Build response headers."""
-        {"request_content": self.deserializer.deserialize_data(request.data)}
+        return {"request_content": self.deserializer.deserialize_data(request.data)}
 
     def load_search_request(self, *args, **kwargs):
         """Load a search request."""
-        {"request_args": self.args_parser.parse()}
+        return {"request_args": self.args_parser.parse()}

--- a/flask_resources/loaders.py
+++ b/flask_resources/loaders.py
@@ -42,13 +42,13 @@ class RequestLoader(LoaderMixin):
     def load_item_request(self, data=True, *args, **kwargs):
         """Build response headers."""
         if data:
-            resource_requestctx.request_content = self.deserializer.deserialize_object(
+            resource_requestctx.request_content = self.deserializer.deserialize_data(
                 request.data
             )
 
     def load_create_request(self, *args, **kwargs):
         """Load an item creation request."""
-        resource_requestctx.request_content = self.deserializer.deserialize_object(
+        resource_requestctx.request_content = self.deserializer.deserialize_data(
             request.data
         )
 

--- a/flask_resources/loaders.py
+++ b/flask_resources/loaders.py
@@ -19,10 +19,6 @@ class LoaderMixin:
         """Load a request concerning an existing item."""
         raise NotImplementedError()
 
-    def load_create_request(self, *args, **kwargs):
-        """Load an item creation request."""
-        raise NotImplementedError()
-
     def load_search_request(self, *args, **kwargs):
         """Load a search request."""
         raise NotImplementedError()
@@ -39,19 +35,10 @@ class RequestLoader(LoaderMixin):
         self.deserializer = deserializer
         self.args_parser = args_parser
 
-    def load_item_request(self, data=True, *args, **kwargs):
+    def load_item_request(self, *args, **kwargs):
         """Build response headers."""
-        if data:
-            resource_requestctx.request_content = self.deserializer.deserialize_data(
-                request.data
-            )
-
-    def load_create_request(self, *args, **kwargs):
-        """Load an item creation request."""
-        resource_requestctx.request_content = self.deserializer.deserialize_data(
-            request.data
-        )
+        {"request_content": self.deserializer.deserialize_data(request.data)}
 
     def load_search_request(self, *args, **kwargs):
         """Load a search request."""
-        resource_requestctx.request_args = self.args_parser.parse()
+        {"request_args": self.args_parser.parse()}

--- a/flask_resources/resources.py
+++ b/flask_resources/resources.py
@@ -17,9 +17,8 @@ from .response import ItemResponse, ListResponse
 from .serializers import JSONSerializer
 from .views import ItemView, ListView, SingletonView
 
-ITEM_VIEW_SUFFIX = "_item_view"
-LIST_VIEW_SUFFIX = "_list_view"
-SINGLETON_VIEW_SUFFIX = "_singleton_view"
+ITEM_VIEW_SUFFIX = "_item"
+LIST_VIEW_SUFFIX = "_list"
 
 
 class ResourceConfig:
@@ -39,17 +38,17 @@ class ResourceConfig:
 class Resource:
     """Resource controller interface."""
 
-    def __init__(self, config=ResourceConfig, *args, **kwargs):
+    def __init__(self, config=ResourceConfig):
         """Initialize the base resource."""
         self.config = config
         self.bp_name = None
 
     # Primary interface
-    def search(self, request_context):
+    def search(self, *args, **kwargs):
         """Perform a search over the items."""
         raise MethodNotAllowed()
 
-    def create(self):
+    def create(self, *args, **kwargs):
         """Create an item."""
         raise MethodNotAllowed()
 
@@ -86,7 +85,7 @@ class Resource:
             {
                 "rule": self.config.item_route,
                 "view_func": ItemView.as_view(
-                    name="{}{}".format(bp_name, ITEM_VIEW_SUFFIX), resource=self,
+                    name="{}".format(bp_name), resource=self,
                 ),
             }
         ]
@@ -126,7 +125,7 @@ class SingletonResource(Resource):
             {
                 "rule": self.config.list_route,
                 "view_func": SingletonView.as_view(
-                    name="{}{}".format(bp_name, SINGLETON_VIEW_SUFFIX), resource=self,
+                    name="{}".format(bp_name), resource=self,
                 ),
             }
         ]

--- a/flask_resources/response.py
+++ b/flask_resources/response.py
@@ -17,10 +17,7 @@ class ResponseMixin:
 
     def make_header(self, content=None):
         """Build response headers."""
-        return {
-            "content-type": resource_requestctx.payload_mimetype,
-            "accept": resource_requestctx.accept_mimetype,
-        }
+        return {"content-type": resource_requestctx.payload_mimetype}
 
     def make_response(self, code, content):
         """Builds a response."""
@@ -37,7 +34,7 @@ class ItemResponse(ResponseMixin):
     Builds up a reponse for a single object.
     """
 
-    def __init__(self, serializer=None, *args, **kwargs):
+    def __init__(self, serializer=None):
         """Constructor."""
         self.serializer = serializer
 
@@ -63,7 +60,7 @@ class ListResponse(ResponseMixin):
     Builds up a reponse for a list of objects.
     """
 
-    def __init__(self, serializer=None, *args, **kwargs):
+    def __init__(self, serializer=None):
         """Constructor."""
         self.serializer = serializer
 

--- a/flask_resources/views/collections.py
+++ b/flask_resources/views/collections.py
@@ -36,7 +36,7 @@ class ListView(BaseView):
 
     def post(self, *args, **kwargs):
         """Create an item in the collection."""
-        resource_requestctx.request_loader.load_create_request()
+        resource_requestctx.request_loader.load_item_request()
 
         return resource_requestctx.response_handler.make_response(
             *self.resource.create(*args, **kwargs)  # data is passed in the context
@@ -58,8 +58,6 @@ class ItemView(BaseView):
     def get(self, *args, **kwargs):
         """Get."""
         try:
-            resource_requestctx.request_loader.load_item_request(data=False)
-
             return resource_requestctx.response_handler.make_response(
                 *self.resource.read(*args, **kwargs)
             )
@@ -91,8 +89,6 @@ class ItemView(BaseView):
     def delete(self, *args, **kwargs):
         """Delete."""
         try:
-            resource_requestctx.request_loader.load_item_request(data=False)
-
             return resource_requestctx.response_handler.make_response(
                 *self.resource.delete(*args, **kwargs)
             )

--- a/flask_resources/views/collections.py
+++ b/flask_resources/views/collections.py
@@ -28,7 +28,9 @@ class ListView(BaseView):
 
     def get(self, *args, **kwargs):
         """Search the collection."""
-        resource_requestctx.request_loader.load_search_request()
+        resource_requestctx.update(
+            resource_requestctx.request_loader.load_search_request()
+        )
 
         return resource_requestctx.response_handler.make_response(
             *self.resource.search(*args, **kwargs)
@@ -36,7 +38,9 @@ class ListView(BaseView):
 
     def post(self, *args, **kwargs):
         """Create an item in the collection."""
-        resource_requestctx.request_loader.load_item_request()
+        resource_requestctx.update(
+            resource_requestctx.request_loader.load_item_request()
+        )
 
         return resource_requestctx.response_handler.make_response(
             *self.resource.create(*args, **kwargs)  # data is passed in the context
@@ -67,8 +71,9 @@ class ItemView(BaseView):
     def put(self, *args, **kwargs):
         """Put."""
         try:
-            resource_requestctx.request_loader.load_item_request()
-
+            resource_requestctx.update(
+                resource_requestctx.request_loader.load_item_request()
+            )
             return resource_requestctx.response_handler.make_response(
                 *self.resource.update(*args, **kwargs)  # data is passed in the context
             )
@@ -78,8 +83,9 @@ class ItemView(BaseView):
     def patch(self, *args, **kwargs):
         """Patch."""
         try:
-            resource_requestctx.request_loader.load_item_request()
-
+            resource_requestctx.update(
+                resource_requestctx.request_loader.load_item_request()
+            )
             return resource_requestctx.response_handler.make_response(
                 *self.resource.partial_update(*args, **kwargs)
             )


### PR DESCRIPTION
Requires #43

Closes #14 

Open questions for accept mimetype:

- Default is currently `None`. Do we want this configurable.
- The arg accept type is hardcoded to `{}`, how do we wanna go about it? should it come from argument parsing? how does it fit along with it?

In any case, the formats content negotiation can be shelved for another issue. We have with this a working module.