### PR TITLE
35 remove reserved keywords clobbering

### DIFF
--- a/flask_resources/context.py
+++ b/flask_resources/context.py
@@ -48,6 +48,7 @@ class ResourceRequestCtx(object):
         self.payload_mimetype = payload_mimetype  # Content-Type
         self.request_args = request_args
         self.request_content = data
+        self.route = {}
 
     def __enter__(self):
         """Push the resource context manager on the current request."""
@@ -70,5 +71,21 @@ def with_resource_requestctx(f):
     def inner(*args, **kwargs):
         with ResourceRequestCtx():
             return f(*args, **kwargs)
+
+    return inner
+
+
+def with_route(f):
+    """Wrapper to extract route arguments into resource context.
+
+    NOTE: This removes the need for *args, **kwargs passing in Resource methods
+    TODO: This should be temporary because the whole decorator approach should be
+          revisited.
+    """
+
+    @wraps(f)
+    def inner(*args, **kwargs):
+        resource_requestctx.route = kwargs
+        return f(*args)
 
     return inner

--- a/flask_resources/deserializers/json.py
+++ b/flask_resources/deserializers/json.py
@@ -17,4 +17,4 @@ class JSONDeserializer(DeserializerMixin):
 
     def deserialize_data(self, data, *args, **kwargs):
         """Deserializes the input data into json."""
-        return json.loads(data)
+        return json.loads(data) if data else {}

--- a/flask_resources/serializers/json.py
+++ b/flask_resources/serializers/json.py
@@ -15,13 +15,13 @@ from .serializers import SerializerMixin
 class JSONSerializer(SerializerMixin):
     """JSON serializer implementation."""
 
-    def serialize_object(self, object, response_ctx=None, *args, **kwargs):
+    def serialize_object(self, obj, response_ctx=None, *args, **kwargs):
         """Dump the object into a json string."""
-        return json.dumps(object)
+        return json.dumps(obj)
 
-    def serialize_object_list(self, object_list, response_ctx=None, *args, **kwargs):
+    def serialize_object_list(self, obj_list, response_ctx=None, *args, **kwargs):
         """Dump the object list into a json string."""
-        return json.dumps(object_list)
+        return json.dumps(obj_list)
 
     def serialize_error(self, error, response_ctx=None, *args, **kwargs):
         """Serialize an error reponse according to the response ctx."""

--- a/flask_resources/serializers/serializers.py
+++ b/flask_resources/serializers/serializers.py
@@ -11,14 +11,14 @@
 class SerializerMixin:
     """Serializer Interface."""
 
-    def serialize_object(self, object, response_ctx=None, *args, **kwargs):
+    def serialize_object(self, obj, response_ctx=None, *args, **kwargs):
         """Serialize a single object according to the response ctx.
 
         The object type must implement ``SerializableMixin``.
         """
         raise NotImplementedError()
 
-    def serialize_object_list(self, object_list, response_ctx=None, *args, **kwargs):
+    def serialize_object_list(self, obj_list, response_ctx=None, *args, **kwargs):
         """Serialize a list of objects according to the response ctx.
 
         Each object type of the list should implement ``SerializableMixin``.

--- a/flask_resources/views/base.py
+++ b/flask_resources/views/base.py
@@ -21,9 +21,7 @@ from ..context import with_resource_requestctx, with_route
 class BaseView(MethodView):
     """Base view."""
 
-    resource_decorators = [
-        content_negotiation, with_route, with_resource_requestctx
-    ]
+    resource_decorators = [content_negotiation, with_route, with_resource_requestctx]
     """Resource-specific decorators to be applied to the views."""
 
     def __init__(self, resource, *args, **kwargs):

--- a/flask_resources/views/base.py
+++ b/flask_resources/views/base.py
@@ -15,13 +15,15 @@ The views responsabilities are:
 from flask.views import MethodView
 
 from ..content_negotiation import content_negotiation
-from ..context import with_resource_requestctx
+from ..context import with_resource_requestctx, with_route
 
 
 class BaseView(MethodView):
     """Base view."""
 
-    resource_decorators = [content_negotiation, with_resource_requestctx]
+    resource_decorators = [
+        content_negotiation, with_route, with_resource_requestctx
+    ]
     """Resource-specific decorators to be applied to the views."""
 
     def __init__(self, resource, *args, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,9 +52,17 @@ class CustomResource(CollectionResource):
 
         return 201, self.db
 
-    def read(self, id):
+    def read(self):
         """Read."""
-        return 200, {"id": id, "content": self.db[id]}
+        _id = resource_requestctx.route["id"]
+        return 200, {"id": _id, "content": self.db[_id]}
+
+    def delete(self):
+        """Delete."""
+        _id = resource_requestctx.route["id"]
+        if _id in self.db:
+            del self.db[_id]
+        return 200, {}
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -59,14 +59,15 @@ def test_custom_resource(client):
     # Search for the previously created obj
     resource_obj = client.get("/custom/", headers=headers)
     assert resource_obj.status_code == 200
-
-    resource_obj_json = resource_obj.json
     assert len(resource_obj.json) == 1
-    assert resource_obj_json[0]["id"] == "1234-ABCD"
+    assert resource_obj.json[0]["id"] == "1234-ABCD"
 
     # Get the previously created obj
     resource_obj = client.get("/custom/1234-ABCD", headers=headers)
     assert resource_obj.status_code == 200
+    assert resource_obj.json["id"] == "1234-ABCD"
 
-    resource_obj_json = resource_obj.json
-    assert resource_obj_json["id"] == "1234-ABCD"
+    # Delete the previously created obj
+    resource_obj = client.delete("/custom/1234-ABCD", headers=headers)
+    assert resource_obj.status_code == 200
+    assert resource_obj.json == {}


### PR DESCRIPTION
NOTE: By introducing route arguments extraction, defining `*args, **kwargs` should not be necessary for Resource methods anymore I believe. I didn't change the signature though until you double-check.

closes #35 