### PR TITLE
responses: rename module and refactor handlers structure

### DIFF
--- a/flask_resources/resources.py
+++ b/flask_resources/resources.py
@@ -13,7 +13,7 @@ from werkzeug.exceptions import MethodNotAllowed
 from .deserializers import JSONDeserializer
 from .loaders import RequestLoader
 from .parsers import search_request_parser
-from .response import ItemResponse, ListResponse
+from .responses import Response
 from .serializers import JSONSerializer
 from .views import ItemView, ListView, SingletonView
 
@@ -29,9 +29,8 @@ class ResourceConfig:
             deserializer=JSONDeserializer(), args_parser=search_request_parser,
         )
     }
-    item_response_handlers = {"application/json": ItemResponse(JSONSerializer())}
+    response_handlers = {"application/json": Response(JSONSerializer())}
     item_route = "/resources/<id>"
-    list_response_handlers = {"application/json": ListResponse(JSONSerializer())}
     list_route = "/resources/"
 
 

--- a/flask_resources/responses.py
+++ b/flask_resources/responses.py
@@ -19,7 +19,11 @@ class ResponseMixin:
         """Build response headers."""
         return {"content-type": resource_requestctx.payload_mimetype}
 
-    def make_response(self, content, code):
+    def make_item_response(self, content, code):
+        """Builds a response."""
+        raise NotImplementedError()
+
+    def make_list_response(self, content, code):
         """Builds a response."""
         raise NotImplementedError()
 
@@ -28,17 +32,17 @@ class ResponseMixin:
         raise NotImplementedError()
 
 
-class ItemResponse(ResponseMixin):
-    """Item response representation.
+class Response(ResponseMixin):
+    """Response implementation.
 
-    Builds up a reponse for a single object.
+    Builds up a reponse for a single or list of objects.
     """
 
     def __init__(self, serializer=None):
         """Constructor."""
         self.serializer = serializer
 
-    def make_response(self, content, code=200):
+    def make_item_response(self, content, code=200):
         """Builds a response for a single object."""
         # https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.make_response
         # (body, status, header)
@@ -47,24 +51,7 @@ class ItemResponse(ResponseMixin):
             self.serializer.serialize_object(content), code, self.make_headers(),
         )
 
-    def make_error_response(self, error):
-        """Builds an error response."""
-        return make_response(
-            self.serializer.serialize_error(error), error.code, self.make_headers()
-        )
-
-
-class ListResponse(ResponseMixin):
-    """List response representation.
-
-    Builds up a reponse for a list of objects.
-    """
-
-    def __init__(self, serializer=None):
-        """Constructor."""
-        self.serializer = serializer
-
-    def make_response(self, content, code=200):
+    def make_list_response(self, content, code=200):
         """Builds a response for a list of objects."""
         # https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.make_response
         # (body, status, header)
@@ -75,8 +62,6 @@ class ListResponse(ResponseMixin):
 
     def make_error_response(self, error):
         """Builds an error response."""
-        # FIXME: Repeated code with above. Is there a chance of having a
-        # Response w/o a serializer? If not this can refactor on parent mixin.
         return make_response(
-            self.serializer.serialize_error(error), error.code, self.make_headers()
+            self.serializer.serialize_error(error), error.code, self.make_headers(),
         )

--- a/flask_resources/views/collections.py
+++ b/flask_resources/views/collections.py
@@ -23,7 +23,7 @@ class ListView(BaseView):
     def __init__(self, *args, **kwargs):
         """Constructor."""
         super(ListView, self).__init__(*args, **kwargs)
-        self._response_handlers = self.resource.config.list_response_handlers
+        self._response_handlers = self.resource.config.response_handlers
         self._request_loaders = self.resource.config.request_loaders
 
     def get(self, *args, **kwargs):
@@ -32,7 +32,7 @@ class ListView(BaseView):
             resource_requestctx.request_loader.load_search_request()
         )
 
-        return resource_requestctx.response_handler.make_response(
+        return resource_requestctx.response_handler.make_list_response(
             *self.resource.search(*args, **kwargs)
         )
 
@@ -42,7 +42,7 @@ class ListView(BaseView):
             resource_requestctx.request_loader.load_item_request()
         )
 
-        return resource_requestctx.response_handler.make_response(
+        return resource_requestctx.response_handler.make_item_response(
             *self.resource.create(*args, **kwargs)  # data is passed in the context
         )
 
@@ -56,13 +56,13 @@ class ItemView(BaseView):
     def __init__(self, *args, **kwargs):
         """Constructor."""
         super(ItemView, self).__init__(*args, **kwargs)
-        self._response_handlers = self.resource.config.item_response_handlers
+        self._response_handlers = self.resource.config.response_handlers
         self._request_loaders = self.resource.config.request_loaders
 
     def get(self, *args, **kwargs):
         """Get."""
         try:
-            return resource_requestctx.response_handler.make_response(
+            return resource_requestctx.response_handler.make_item_response(
                 *self.resource.read(*args, **kwargs)
             )
         except HTTPException as error:
@@ -74,7 +74,7 @@ class ItemView(BaseView):
             resource_requestctx.update(
                 resource_requestctx.request_loader.load_item_request()
             )
-            return resource_requestctx.response_handler.make_response(
+            return resource_requestctx.response_handler.make_item_response(
                 *self.resource.update(*args, **kwargs)  # data is passed in the context
             )
         except HTTPException as error:
@@ -86,7 +86,7 @@ class ItemView(BaseView):
             resource_requestctx.update(
                 resource_requestctx.request_loader.load_item_request()
             )
-            return resource_requestctx.response_handler.make_response(
+            return resource_requestctx.response_handler.make_item_response(
                 *self.resource.partial_update(*args, **kwargs)
             )
         except HTTPException as error:
@@ -95,7 +95,7 @@ class ItemView(BaseView):
     def delete(self, *args, **kwargs):
         """Delete."""
         try:
-            return resource_requestctx.response_handler.make_response(
+            return resource_requestctx.response_handler.make_item_response(
                 *self.resource.delete(*args, **kwargs)
             )
         except HTTPException as error:


### PR DESCRIPTION
Replaces https://github.com/inveniosoftware/flask-resources/pull/50
Closes https://github.com/inveniosoftware/flask-resources/issues/48

It was noticed when making the response for the search `GET` action on the `ListView`, it requires the old `ListResponse` while the create `POST` requires the old `ItemResponse`. The `ListView` was only getting the `ListReponse` class.

**Solution**

Merge both response classes in one, which will have to methods: `make_item_response` and `make_list_response`.

**Why/Motivation**

Both `ItemResponse` and `ListReponse`:

- Have the same constructor
- Use the same serializer for a view, i.e. even if only calling one of their functions (list or item) depending on which response class is calling the serializer is the same per view.
- Serializers follow this pattern and is cleaner (One serializer with `serialize_obj` and `serialize_obj_list` methods).

As for the naming... All modules (loaders, serializers, resources) are called in plural, however response is singular. Therefore, it got renamed.