### PR TITLE
save original request information

### DIFF
--- a/flask_resources/content_negotiation.py
+++ b/flask_resources/content_negotiation.py
@@ -9,7 +9,6 @@
 
 from functools import wraps
 
-from flask import request
 from werkzeug.datastructures import MIMEAccept
 from werkzeug.exceptions import NotAcceptable
 
@@ -90,9 +89,9 @@ def content_negotiation(f):
         # mimetype?
         accept_mimetype = ContentNegotiator.match(
             self.resource.config.response_handlers.keys(),
-            request.accept_mimetypes,
+            resource_requestctx.original_request['accept_mimetypes'],
             {},  # TODO: Rely on config to populate this formats_map
-            request.args.get("format", None),
+            resource_requestctx.original_request['args'].get("format", None),
         )
 
         if not accept_mimetype:

--- a/flask_resources/loaders.py
+++ b/flask_resources/loaders.py
@@ -9,7 +9,6 @@
 
 from functools import wraps
 
-from flask import request
 from werkzeug.exceptions import UnsupportedMediaType
 
 from .context import resource_requestctx
@@ -26,11 +25,12 @@ def request_loader(f):
         """
         # Checking Content-Type is the responsibility of the loader
         loaders = self.resource.config.request_loaders
+        original_request = resource_requestctx.original_request
 
-        if request.content_type not in loaders:
+        if original_request['content_type'] not in loaders:
             raise UnsupportedMediaType()
 
-        self.request_loader = loaders[request.content_type]
+        self.request_loader = loaders[original_request['content_type']]
 
         return f(self, *args, **kwargs)
 
@@ -62,7 +62,9 @@ class RequestLoader(LoaderMixin):
 
     def load_item_request(self, *args, **kwargs):
         """Build response headers."""
-        return {"request_content": self.deserializer.deserialize_data(request.data)}
+        return {
+            "request_content": self.deserializer.deserialize_data(
+                                resource_requestctx.original_request['data'])}
 
     def load_search_request(self, *args, **kwargs):
         """Load a search request."""

--- a/flask_resources/parsers/parsers.py
+++ b/flask_resources/parsers/parsers.py
@@ -7,7 +7,6 @@
 
 """Library for easily implementing REST APIs."""
 
-from flask import request
 from marshmallow.validate import Range, Regexp
 from webargs.fields import Int, String
 from webargs.flaskparser import parser
@@ -25,7 +24,7 @@ class RequestParser:
 
     def parse(self, *args, **kwargs):
         """Parse."""
-        return self.post_process(parser.parse(self.fields, request, *args, **kwargs))
+        return self.post_process(parser.parse(self.fields, *args, **kwargs))
 
     def post_process(self, request_arguments, *args, **kwargs):
         """Post process."""

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -72,3 +72,37 @@ def test_custom_resource(client):
     resource_obj = client.delete("/custom/1234-ABCD", headers=headers)
     assert resource_obj.status_code == 200
     assert resource_obj.json == {}
+
+
+def test_custom_resource_only_json_content(client):
+    """Test a custom resource forcing json content-type."""
+    headers = {"content-type": "application/xml", "accept": "application/json"}
+
+    # The resource returns a list, empty for now
+    resource_obj = client.get("/only-json-content/", headers=headers)
+    assert resource_obj.status_code == 200
+    assert len(resource_obj.json) == 0
+
+    # Create a resource object
+    obj_content = {"id": "1234-ABCD", "content": "test resource obj content"}
+    obj_json = json.dumps(obj_content)
+    resource_obj = client.post(
+        "/only-json-content/", data=obj_json, headers=headers)
+    assert resource_obj.status_code == 201
+
+    # Search for the previously created obj
+    resource_obj = client.get("/only-json-content/", headers=headers)
+    assert resource_obj.status_code == 200
+    assert len(resource_obj.json) == 1
+    assert resource_obj.json[0]["id"] == "1234-ABCD"
+
+    # Get the previously created obj
+    resource_obj = client.get("/only-json-content/1234-ABCD", headers=headers)
+    assert resource_obj.status_code == 200
+    assert resource_obj.json["id"] == "1234-ABCD"
+
+    # Delete the previously created obj
+    resource_obj = client.delete(
+        "/only-json-content/1234-ABCD", headers=headers)
+    assert resource_obj.status_code == 200
+    assert resource_obj.json == {}


### PR DESCRIPTION
**Prototype version**: An example on how it would feel if we store `flask.request` information in the resource request context in the beginning of the request lifecycle. Also, resource request is configurable.

**Pros**
- You could imitate a request without having an active request context by just inheriting the `ResourceRequestCtx` class and override the `inject_original_request` method i.e as it is done in the `conftest.py`.
- Storing the `flask.request` metadata to an attribute instead of flattening it, would make easier the debugging of the initial request data. In case of flattening, we would need to prefix the `flask.request` information so they can be distinguished but you would have to iterate to them one by one to have the full picture of the initial request. FYI, `requests` library in python stores the `request` object requested the response, see [Response.request](https://www.w3schools.com/python/ref_requests_response.asp) attribute.