### PR TITLE
Add collection list methods

### DIFF
--- a/flask_resources/__init__.py
+++ b/flask_resources/__init__.py
@@ -7,12 +7,13 @@
 
 """Library for easily implementing REST APIs."""
 
-from .resources import CollectionResource, Resource, SingletonResource
+from .resources import CollectionResource, Resource, ResourceConfig, SingletonResource
 from .version import __version__
 
 __all__ = (
     "__version__",
     "Resource",
+    "ResourceConfig",
     "CollectionResource",
     "SingletonResource",
 )

--- a/flask_resources/resources.py
+++ b/flask_resources/resources.py
@@ -100,6 +100,14 @@ class Resource:
 class CollectionResource(Resource):
     """CollectionResource."""
 
+    def update_all(self, *args, **kwargs):
+        """Delete an item."""
+        return [], 200
+
+    def delete_all(self, *args, **kwargs):
+        """Delete an item."""
+        return [], 200
+
     def create_url_rules(self, bp_name):
         """Create url rules."""
         return [

--- a/flask_resources/views/collections.py
+++ b/flask_resources/views/collections.py
@@ -49,6 +49,18 @@ class ListView(BaseView):
             *self.resource.create(*args, **kwargs)  # data is passed in the context
         )
 
+    def put(self, *args, **kwargs):
+        """Update the collection."""
+        return self.response_handler.make_list_response(
+            *self.resource.update_all(*args, **kwargs)
+        )
+
+    def delete(self, *args, **kwargs):
+        """Delete the collection."""
+        return self.response_handler.make_list_response(
+            *self.resource.delete_all(*args, **kwargs)
+        )
+
 
 class ItemView(BaseView):
     """Item view representation.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,12 @@ class CustomResource(CollectionResource):
             del self.db[_id]
         return {}, 200
 
+    def update_all(self):
+        """Delete."""
+        for obj in resource_requestctx.request_content:
+            self.db[obj["id"]] = obj["content"]
+        return resource_requestctx.request_content, 200
+
 
 @pytest.fixture(scope="module")
 def app():

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -59,13 +59,6 @@ def test_405_if_route_but_no_method(client):
     #       didn't define in its MethodViews
     # NOTE: For now we just test the methods that this library
     #       didn't define in its MethodViews
-    # List-level
-    response = client.put("/custom/")
-    assert response.status_code == 405
-
-    response = client.delete("/custom/")
-    assert response.status_code == 405
-
     # Item-level
     response = client.post("/custom/1")
     assert response.status_code == 405

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -73,3 +73,14 @@ def test_custom_resource(client):
     resource_obj = client.delete("/custom/1234-ABCD", headers=headers)
     assert resource_obj.status_code == 200
     assert resource_obj.json == {}
+
+    # PUT/Edit a list of resource units
+    obj_json = json.dumps([{"id": "1234-ABCD", "content": "updated content"}])
+    response = client.put("/custom/", data=obj_json, headers=headers)
+    assert response.status_code == 200
+    assert response.json == [{"id": "1234-ABCD", "content": "updated content"}]
+
+    # DELETE/remove a list of resource units
+    response = client.delete("/custom/", headers=headers)
+    assert response.status_code == 200
+    assert response.json == []


### PR DESCRIPTION
Add delete_all and update_all for list_route of CollectionResource like talked about with @lnielsen . This is to allow `/records/<pid_value>/draft/files` PUT and DELETE for invenio-drafts-resources. Even though SingletonResource could be used, the semantic was strange there. 

Also exposes ResourceConfig directly: `from flask_resources import ResourceConfig` is now possible like `from flask_resources import Resource` 

closes https://github.com/inveniosoftware/invenio-resources/issues/22