### PR TITLE
parsers: allow or disallow unknown URL args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_install:
 install:
   - "travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt"
   - "travis_retry pip install -e .[all]"
+  - pip freeze
 
 script:
   - ./run-tests.sh

--- a/flask_resources/resources.py
+++ b/flask_resources/resources.py
@@ -93,7 +93,8 @@ class Resource:
             {
                 "rule": self.config.item_route,
                 "view_func": ItemView.as_view(
-                    name="{}".format(bp_name), resource=self,
+                    name=f"{bp_name}",
+                    resource=self,
                 ),
             }
         ]
@@ -121,13 +122,15 @@ class CollectionResource(Resource):
             {
                 "rule": self.config.item_route,
                 "view_func": ItemView.as_view(
-                    name="{}{}".format(bp_name, ITEM_VIEW_SUFFIX), resource=self,
+                    name=f"{bp_name}{ITEM_VIEW_SUFFIX}",
+                    resource=self,
                 ),
             },
             {
                 "rule": self.config.list_route,
                 "view_func": ListView.as_view(
-                    name="{}{}".format(bp_name, LIST_VIEW_SUFFIX), resource=self,
+                    name=f"{bp_name}{LIST_VIEW_SUFFIX}",
+                    resource=self,
                 ),
             },
         ]
@@ -142,7 +145,8 @@ class SingletonResource(Resource):
             {
                 "rule": self.config.list_route,
                 "view_func": SingletonView.as_view(
-                    name="{}".format(bp_name), resource=self,
+                    name=f"{bp_name}",
+                    resource=self,
                 ),
             }
         ]

--- a/flask_resources/responses.py
+++ b/flask_resources/responses.py
@@ -68,7 +68,9 @@ class Response(ResponseMixin):
         # (body, status, header)
 
         return make_response(
-            self.serializer.serialize_object(content), code, self.make_headers(),
+            self.serializer.serialize_object(content),
+            code,
+            self.make_headers(),
         )
 
     def make_list_response(self, content, code=200):
@@ -77,5 +79,7 @@ class Response(ResponseMixin):
         # (body, status, header)
 
         return make_response(
-            self.serializer.serialize_object_list(content), code, self.make_headers(),
+            self.serializer.serialize_object_list(content),
+            code,
+            self.make_headers(),
         )


### PR DESCRIPTION
Needed for aggregation work.

Not available in webargs 5.x < 6.x . See https://webargs.readthedocs.io/en/latest/upgrading.html#data-is-not-filtered-before-being-passed-to-schemas-and-it-may-be-proxified
