### PR TITLE
don't be fancy with unknown url args

### DIFF
--- a/flask_resources/parsers/parsers.py
+++ b/flask_resources/parsers/parsers.py
@@ -77,14 +77,7 @@ class ArgsParser(object):
         # NOTE: This has to be done bc webargs 5.X < 6.X doesn't obey schemas that
         #       allow unknown fields. webargs 6.X does, so this can be changed when
         #       upgrading dependencies
-        if self.allow_unknown:
-            raw_args = {
-                k: v[0] if len(v) == 1 else v
-                for k, v in request.args.to_dict(flat=False).items()
-            }
-        else:
-            raw_args = {}
-
+        raw_args = request.args.to_dict(flat=False) if self.allow_unknown else {}
         flaskparser = ResourceFlaskParser()
         # WARNING: This interface changes from webargs 5.5.3 (version we use) to
         #          webargs 6.X (most recent webargs version). In 6.x it is

--- a/flask_resources/version.py
+++ b/flask_resources/version.py
@@ -11,4 +11,4 @@ This file is imported by ``flask_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "black>=19.10b0",
+    "black>=20.8b1,<20.9b0",
     "check-manifest>=0.25",
     # coverage pinned because of https://github.com/nedbat/coveragepy/issues/716
     "coverage>=4.0,<5.0.0",

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -183,7 +183,7 @@ def test_parser_raises_400(client):
 def test_parser_includes_or_excludes_unknown_args(client):
     response = client.get("/method?num=10&foo=20&bar=1&foo=10", headers=HEADERS)
     assert response.status_code == 200
-    assert response.json == {"num": 10, "lang": "", "foo": ["20", "10"], "bar": "1"}
+    assert response.json == {"num": 10, "lang": "", "foo": ["20", "10"], "bar": ["1"]}
 
     response = client.get("/universal?num=10&foo=20&bar=1&foo=10", headers=HEADERS)
     assert response.status_code == 200


### PR DESCRIPTION
Stopped being fancy about unknown url args parsing. Since
url args can be repeated (type=A&type=B), it is much simpler
to always parse them as lists.

Also upper-bounded black. It's in beta and has different opinions
for each version :(