### PR TITLE
parsers: default to not include unknown parameters

### DIFF
--- a/flask_resources/parsers/__init__.py
+++ b/flask_resources/parsers/__init__.py
@@ -9,11 +9,13 @@
 """Library for easily implementing REST APIs."""
 
 from .headers import HeadersParser, headers_parser
+from .schema import MultiDictSchema
 from .url_args import URLArgsParser, url_args_parser
 
 __all__ = (
-    "HeadersParser",
     "headers_parser",
-    "URLArgsParser",
+    "HeadersParser",
+    "MultiDictSchema",
     "url_args_parser",
+    "URLArgsParser",
 )

--- a/flask_resources/parsers/headers.py
+++ b/flask_resources/parsers/headers.py
@@ -1,29 +1,30 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
-# Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2020-2021 Northwestern University.
 #
 # Flask-Resources is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-"""Library for easily implementing REST APIs."""
+"""Header parser."""
 
 from flask import request
 
 from .base import RequestParser, request_parser_decorator
 
 
-def _raw_args(*args, **kwargs):
-    return {**request.headers}
-
-
 class HeadersParser(RequestParser):
     """Headers parser."""
 
-    location = "headers"
-    raw_args_fn = _raw_args
+    def load_data(self):
+        """Load data from headers."""
+        return {k.lower().replace("-", "_"): v for (k, v) in request.headers.items()}
 
 
 headers_parser = request_parser_decorator(
-    HeadersParser, "request_headers_parser", "headers"
+    HeadersParser,
+    # Attribute name on the resource config
+    "request_headers_parser",
+    # Attribute name on the resource_requestctx
+    "headers",
 )

--- a/flask_resources/parsers/schema.py
+++ b/flask_resources/parsers/schema.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Flask-Resources is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Schema that's able to handle loading data from MultiDicts."""
+
+import marshmallow as ma
+from werkzeug.datastructures import MultiDict
+
+
+class MultiDictSchema(ma.Schema):
+    """MultiDict aware schema used for loading e.g. request.args."""
+
+    class Meta:
+        """Throw away unknown values."""
+
+        unknown = ma.EXCLUDE
+
+    LIST_TYPES = [
+        ma.fields.List,
+    ]
+
+    @classmethod
+    def is_list_field(cls, field):
+        """Method used to determine if a field is a list type field.
+
+        This is used to unpack the MultiDict into a normal dictionary.
+        """
+        return any((isinstance(field, t) for t in cls.LIST_TYPES))
+
+    @ma.pre_load
+    def flatten_multidict(self, data, **kwargs):
+        """Flatten a MultiDict into a normal dictionary."""
+        if not isinstance(data, MultiDict):
+            return data
+        data = data.to_dict(flat=False)
+
+        for name, field in self.fields.items():
+            if name in data and not self.is_list_field(field):
+                data[name] = data[name][0]
+        return data

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup_requires = ["Babel>=1.3"]
 
 install_requires = [
     "Flask~=1.1.2",
-    "webargs~=5.5.0",
+    "marshmallow~=3.0",
     "speaklater>=1.3,<2.0",
 ]
 

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -10,8 +10,10 @@
 
 import pytest
 from flask import Flask
+from marshmallow import fields
 
 from flask_resources.context import resource_requestctx
+from flask_resources.parsers import HeadersParser
 from flask_resources.resources import CollectionResource, ResourceConfig
 
 # NOTE: mimetype headers have to be provided in general, but the args parsing is not
@@ -26,6 +28,12 @@ class HeaderParserConfig(ResourceConfig):
 
     item_route = "/headers/<id>"
     list_route = "/headers"
+    request_headers_parser = HeadersParser(
+        {
+            "content_type": fields.String(),
+            "accept": fields.String(),
+        }
+    )
 
 
 class HeadersResource(CollectionResource):
@@ -74,10 +82,8 @@ def app():
 @pytest.fixture(scope="module")
 def expected_headers():
     return {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-        "Host": "localhost",
-        "User-Agent": "werkzeug/1.0.1",
+        "accept": "application/json",
+        "content_type": "application/json",
     }
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -10,7 +10,7 @@
 
 import pytest
 from flask import Flask
-from webargs import fields
+from marshmallow import ValidationError, fields
 from werkzeug.exceptions import HTTPException
 
 from flask_resources.context import resource_requestctx
@@ -36,11 +36,9 @@ class UniversalParserConfig(ResourceConfig):
     list_route = "/universal"
     # Because an URLArgsParser is passed directly, it is applied to all endpoints
     request_url_args_parser = URLArgsParser(
-        {"num": fields.Int(), "lang": fields.String(missing="")}, allow_unknown=False
+        {"num": fields.Int(), "lang": fields.String(missing="")}
     )
-    request_headers_parser = HeadersParser(
-        {"content_type": fields.String()}, allow_unknown=False
-    )
+    request_headers_parser = HeadersParser({"content_type": fields.String()})
 
 
 class MethodParserConfig(ResourceConfig):
@@ -52,12 +50,21 @@ class MethodParserConfig(ResourceConfig):
     # to that endpoint
     request_url_args_parser = {
         "search": URLArgsParser(
-            {"num": fields.Int(), "lang": fields.String(missing="")}
+            {"num": fields.Int(), "lang": fields.String(missing="")}, allow_unknown=True
         )
     }
 
     request_headers_parser = {
-        "update": HeadersParser({"content_type": fields.String()}, allow_unknown=False)
+        "update": HeadersParser({"content_type": fields.String()})
+    }
+
+    error_map = {
+        ValidationError: create_errormap_handler(
+            HTTPJSONException(
+                code=400,
+                description="Validation error.",
+            )
+        )
     }
 
 


### PR DESCRIPTION
Changes the default query string/header parsing to **not** include unknowns.