### PR TITLE
serialisers: add marshmallow json serializer

### DIFF
--- a/flask_resources/json_encoder.py
+++ b/flask_resources/json_encoder.py
@@ -8,12 +8,12 @@
 
 """Custom JSON encoder."""
 
-import json
 
+from flask.json import JSONEncoder
 from speaklater import is_lazy_string
 
 
-class CustomJSONEncoder(json.JSONEncoder):
+class CustomJSONEncoder(JSONEncoder):
     """JSONEncoder for our custom needs.
 
     - Knows to force translate lazy translation strings

--- a/flask_resources/parsers/__init__.py
+++ b/flask_resources/parsers/__init__.py
@@ -9,11 +9,13 @@
 """Library for easily implementing REST APIs."""
 
 from .headers import HeadersParser, headers_parser
+from .schema import MultiDictSchema
 from .url_args import URLArgsParser, url_args_parser
 
 __all__ = (
-    "HeadersParser",
     "headers_parser",
-    "URLArgsParser",
+    "HeadersParser",
+    "MultiDictSchema",
     "url_args_parser",
+    "URLArgsParser",
 )

--- a/flask_resources/parsers/headers.py
+++ b/flask_resources/parsers/headers.py
@@ -1,29 +1,30 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
-# Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2020-2021 Northwestern University.
 #
 # Flask-Resources is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-"""Library for easily implementing REST APIs."""
+"""Header parser."""
 
 from flask import request
 
 from .base import RequestParser, request_parser_decorator
 
 
-def _raw_args(*args, **kwargs):
-    return {**request.headers}
-
-
 class HeadersParser(RequestParser):
     """Headers parser."""
 
-    location = "headers"
-    raw_args_fn = _raw_args
+    def load_data(self):
+        """Load data from headers."""
+        return {k.lower().replace("-", "_"): v for (k, v) in request.headers.items()}
 
 
 headers_parser = request_parser_decorator(
-    HeadersParser, "request_headers_parser", "headers"
+    HeadersParser,
+    # Attribute name on the resource config
+    "request_headers_parser",
+    # Attribute name on the resource_requestctx
+    "headers",
 )

--- a/flask_resources/parsers/schema.py
+++ b/flask_resources/parsers/schema.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Flask-Resources is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Schema that's able to handle loading data from MultiDicts."""
+
+import marshmallow as ma
+from werkzeug.datastructures import MultiDict
+
+
+class MultiDictSchema(ma.Schema):
+    """MultiDict aware schema used for loading e.g. request.args."""
+
+    class Meta:
+        """Throw away unknown values."""
+
+        unknown = ma.EXCLUDE
+
+    LIST_TYPES = [
+        ma.fields.List,
+    ]
+
+    @classmethod
+    def is_list_field(cls, field):
+        """Method used to determine if a field is a list type field.
+
+        This is used to unpack the MultiDict into a normal dictionary.
+        """
+        return any((isinstance(field, t) for t in cls.LIST_TYPES))
+
+    @ma.pre_load
+    def flatten_multidict(self, data, **kwargs):
+        """Flatten a MultiDict into a normal dictionary."""
+        if not isinstance(data, MultiDict):
+            return data
+        data = data.to_dict(flat=False)
+
+        for name, field in self.fields.items():
+            if name in data and not self.is_list_field(field):
+                data[name] = data[name][0]
+        return data

--- a/flask_resources/serializers/__init__.py
+++ b/flask_resources/serializers/__init__.py
@@ -7,7 +7,7 @@
 
 """Serializers."""
 
-from .json import JSONSerializer
+from .json import JSONSerializer, MarshmallowJSONSerializer
 from .serializers import SerializerMixin
 
-__all__ = ("JSONSerializer", "SerializerMixin")
+__all__ = ("JSONSerializer", "MarshmallowJSONSerializer", "SerializerMixin")

--- a/flask_resources/serializers/json.py
+++ b/flask_resources/serializers/json.py
@@ -10,17 +10,79 @@
 
 import json
 
+from flask import request
+
 from ..json_encoder import CustomJSONEncoder
 from .serializers import SerializerMixin
+
+
+def flask_request_options():
+    """Options to pretty print the JSON."""
+    if request and request.args.get("prettyprint"):
+        return {
+            "indent": 2,
+            "sort_keys": True,
+        }
+    return {}
 
 
 class JSONSerializer(SerializerMixin):
     """JSON serializer implementation."""
 
-    def serialize_object(self, obj, response_ctx=None, *args, **kwargs):
-        """Dump the object into a json string."""
-        return json.dumps(obj, cls=CustomJSONEncoder)
+    def __init__(self, encoder=None, options=None):
+        """Initialize the JSONSerializer."""
+        self._options = options or flask_request_options
+        self._encoder = encoder or CustomJSONEncoder
 
-    def serialize_object_list(self, obj_list, response_ctx=None, *args, **kwargs):
+    @property
+    def dumps_options(self):
+        """Support adding options for the dumps() method."""
+        return self._options() if callable(self._options) else self._options
+
+    @property
+    def encoder(self):
+        """Support overriding the JSONEncoder used for serialization."""
+        # We let classes through as-is
+        if isinstance(self._encoder, type):
+            return self._encoder
+        elif callable(self._encoder):
+            return self._encoder()
+        return self._encoder
+
+    def serialize_object(self, obj):
+        """Dump the object into a json string."""
+        encoder = self.encoder
+        return json.dumps(obj, cls=encoder, **self.dumps_options)
+
+    def serialize_object_list(self, obj_list):
         """Dump the object list into a json string."""
-        return json.dumps(obj_list, cls=CustomJSONEncoder)
+        return json.dumps(obj_list, cls=self.encoder, **self.dumps_options)
+
+
+class MarshmallowJSONSerializer(JSONSerializer):
+    """JSON serializing using Marshmallow to transform output."""
+
+    def __init__(self, item_schema=None, list_schema=None, **kwargs):
+        """Initialize the serializer."""
+        self._item_schema_cls = item_schema
+        self._list_schema_cls = list_schema
+        super().__init__(**kwargs)
+
+    def serialize_object(self, obj):
+        """Dump the object into a JSON string."""
+        return super().serialize_object(self.dump_item(obj))
+
+    def serialize_object_list(self, obj_list):
+        """Dump the object list into a JSON string."""
+        return super().serialize_object_list(self.dump_list(obj_list))
+
+    def dump_item(self, obj):
+        """Dump the object with extra information."""
+        return self._item_schema_cls().dump(obj)
+
+    def dump_list(self, obj_list):
+        """Dump the list of objects with extra information."""
+        ctx = {
+            "item_schema_cls": self._item_schema_cls,
+        }
+        return self._list_schema_cls(context=ctx).dump(obj_list)

--- a/flask_resources/version.py
+++ b/flask_resources/version.py
@@ -11,4 +11,4 @@ This file is imported by ``flask_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup_requires = ["Babel>=1.3"]
 
 install_requires = [
     "Flask~=1.1.2",
-    "webargs~=5.5.0",
+    "marshmallow~=3.0",
     "speaklater>=1.3,<2.0",
 ]
 

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -10,8 +10,10 @@
 
 import pytest
 from flask import Flask
+from marshmallow import fields
 
 from flask_resources.context import resource_requestctx
+from flask_resources.parsers import HeadersParser
 from flask_resources.resources import CollectionResource, ResourceConfig
 
 # NOTE: mimetype headers have to be provided in general, but the args parsing is not
@@ -26,6 +28,12 @@ class HeaderParserConfig(ResourceConfig):
 
     item_route = "/headers/<id>"
     list_route = "/headers"
+    request_headers_parser = HeadersParser(
+        {
+            "content_type": fields.String(),
+            "accept": fields.String(),
+        }
+    )
 
 
 class HeadersResource(CollectionResource):
@@ -74,10 +82,8 @@ def app():
 @pytest.fixture(scope="module")
 def expected_headers():
     return {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-        "Host": "localhost",
-        "User-Agent": "werkzeug/1.0.1",
+        "accept": "application/json",
+        "content_type": "application/json",
     }
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -10,7 +10,7 @@
 
 import pytest
 from flask import Flask
-from webargs import fields
+from marshmallow import ValidationError, fields
 from werkzeug.exceptions import HTTPException
 
 from flask_resources.context import resource_requestctx
@@ -36,11 +36,9 @@ class UniversalParserConfig(ResourceConfig):
     list_route = "/universal"
     # Because an URLArgsParser is passed directly, it is applied to all endpoints
     request_url_args_parser = URLArgsParser(
-        {"num": fields.Int(), "lang": fields.String(missing="")}, allow_unknown=False
+        {"num": fields.Int(), "lang": fields.String(missing="")}
     )
-    request_headers_parser = HeadersParser(
-        {"content_type": fields.String()}, allow_unknown=False
-    )
+    request_headers_parser = HeadersParser({"content_type": fields.String()})
 
 
 class MethodParserConfig(ResourceConfig):
@@ -52,12 +50,21 @@ class MethodParserConfig(ResourceConfig):
     # to that endpoint
     request_url_args_parser = {
         "search": URLArgsParser(
-            {"num": fields.Int(), "lang": fields.String(missing="")}
+            {"num": fields.Int(), "lang": fields.String(missing="")}, allow_unknown=True
         )
     }
 
     request_headers_parser = {
-        "update": HeadersParser({"content_type": fields.String()}, allow_unknown=False)
+        "update": HeadersParser({"content_type": fields.String()})
+    }
+
+    error_map = {
+        ValidationError: create_errormap_handler(
+            HTTPJSONException(
+                code=400,
+                description="Validation error.",
+            )
+        )
     }
 
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -8,16 +8,18 @@
 
 """Test deserialization."""
 
+import marshmallow as ma
+from flask import Flask, request
 from speaklater import make_lazy_string
 
-from flask_resources.serializers import JSONSerializer
+from flask_resources.serializers import JSONSerializer, MarshmallowJSONSerializer
 
 
 def _(s):
     return make_lazy_string(lambda: s)
 
 
-def test_lazy_strings_are_deserialized():
+def test_lazy_strings_are_serialized():
     serializer = JSONSerializer()
     lazy = {"key": _("Lazy")}
     list_lazy = [{"key": _("Lazy1")}, {"key": _("Lazy2")}]
@@ -26,3 +28,19 @@ def test_lazy_strings_are_deserialized():
     assert '[{"key": "Lazy1"}, {"key": "Lazy2"}]' == serializer.serialize_object_list(
         list_lazy
     )
+
+
+def test_prettyprint():
+    app = Flask("test")
+    with app.test_request_context("/?prettyprint=1"):
+        serializer = JSONSerializer()
+        assert '{\n  "key": "1"\n}' == serializer.serialize_object({"key": "1"})
+
+
+def test_marhsmallow_serializer():
+    class TestSchema(ma.Schema):
+        title = ma.fields.Str(data_key="test")
+
+    s = MarshmallowJSONSerializer(item_schema=TestSchema, list_schema=TestSchema)
+    assert s.serialize_object({"title": "a"}) == '{"test": "a"}'
+    assert s.serialize_object_list({"title": "a"}) == '{"test": "a"}'


### PR DESCRIPTION
**Includes #90**, hence just check the top commit.

⚠️ Added a release commit for v0.5.0 so remember to tag if you merge.

* Improves the JSONSerializer to support functions for getting extra dump options.
* Add support for using ``?prettyprint=1`` to nicely format JSON in output for easier inspection.
* Add MarshmallowJSONSerializer that allows transforming the data before dumping it in JSON.
