### PR TITLE
errors: add logging of exceptions when in debug

### DIFF
--- a/flask_resources/errors.py
+++ b/flask_resources/errors.py
@@ -10,7 +10,7 @@
 
 import json
 
-from flask import g
+from flask import current_app, g
 from werkzeug.exceptions import HTTPException
 
 from .serializers.json import JSONEncoder
@@ -35,6 +35,9 @@ def create_error_handler(map_func_or_exception):
         else:
             mapped_exc = map_func_or_exception(e)
         mapped_exc.__original_exc__ = e
+        current_app.logger.debug(
+            "A resource error handler caught the following exception:", exc_info=True
+        )
         return mapped_exc.get_response()
 
     return error_handler


### PR DESCRIPTION
This makes it a bit easier to understand what's going on for developers.

For instance the resource might catch a RequestError from Elasticsearch, which could be because of syntax error in the query string, but as well there could be something else wrong, but the exception is swallowed by the error handler, so you only get a 400 response. Without the exception it's hard for the developer to determine that RequestError might be too broad an exception.