### PR TITLE
global: make package ready for flask 2

### DIFF
--- a/flask_resources/errors.py
+++ b/flask_resources/errors.py
@@ -73,15 +73,15 @@ class HTTPJSONException(HTTPException):
         """
         return [e for e in self.errors] if self.errors else None
 
-    def get_description(self, environ=None):
+    def get_description(self, environ=None, scope=None):
         """Returns an unescaped description."""
         return self.description
 
-    def get_headers(self, environ=None):
+    def get_headers(self, environ=None, scope=None):
         """Get a list of headers."""
         return [("Content-Type", "application/json")]
 
-    def get_body(self, environ=None):
+    def get_body(self, environ=None, scope=None):
         """Get the request body."""
         body = {"status": self.code, "message": self.get_description(environ)}
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ for reqs in extras_require.values():
 
 
 install_requires = [
-    "Flask>=1.1.4,<2.0.0",
+    "Flask>=1.1.4",
     "marshmallow~=3.0",
     "speaklater>=1.3,<2.0",
 ]

--- a/tests/test_resources_errors.py
+++ b/tests/test_resources_errors.py
@@ -21,6 +21,7 @@ from flask_resources.errors import HTTPJSONException
 @pytest.fixture(scope="module")
 def resource():
     class Config(ResourceConfig):
+        blueprint_name = "hello_world"
         error_handlers = {
             403: create_error_handler(
                 HTTPJSONException(code=403, description="Overwrite existing")


### PR DESCRIPTION
A few changes to make the package ready for use with Flask 2 (still works with Flask 1.x).
For instance, the `HTTPException` getters now expect another positional argument, `scope`: https://github.com/pallets/werkzeug/blob/main/src/werkzeug/exceptions.py#L153-L157
Note: Flask 2.0.1 introduced a check of the Blueprint name on init, which requires the name to be set to some string (i.e. not `None`).