### PR TITLE
fix: remove DeprecationWarning json_encoder

### DIFF
--- a/flask_resources/serializers/json.py
+++ b/flask_resources/serializers/json.py
@@ -11,7 +11,7 @@
 import json
 
 from flask import request
-from flask.json import JSONEncoder as JSONEncoderBase
+from flask.json.provider import _default
 from speaklater import is_lazy_string
 
 from .base import MarshmallowSerializer, SerializerMixin
@@ -27,7 +27,7 @@ def flask_request_options():
     return {}
 
 
-class JSONEncoder(JSONEncoderBase):
+class JSONEncoder(json.JSONEncoder):
     """JSONEncoder for our custom needs.
 
     - Knows to force translate lazy translation strings.
@@ -37,7 +37,7 @@ class JSONEncoder(JSONEncoderBase):
         """Override parent's default."""
         if is_lazy_string(obj):
             return str(obj)
-        return super().default(obj)
+        return _default(obj)
 
 
 class JSONSerializer(SerializerMixin):


### PR DESCRIPTION
* The flask.json.JSONEncoder is set deprecated with Flask v2.2 and
  will be removed with Flask v2.3.

* Flask.json.JSONEncoder was inherited from json.JSONEncoder. This is
  the reason to use that class as the new parent. Flask.json.JSONEncoder
  didn't added something to the constructor, therfore json.JSONEncoder
  is a save parent.

* json.JSONEncoder is not enough. Flask.json.JSONEncoder handled some
  special types with a specialized _default function. This _default
  method is used also in this commit to ensure the same behaviour as
  before.
